### PR TITLE
Fix transformation dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ScalaStan Dependency
 To use ScalaStan, add the following to your build:
 ```scala
 resolvers += Resolver.bintrayRepo("cibotech", "public")
-libraryDependences += "com.cibo" %% "scalastan" % "0.5.6"
+libraryDependences += "com.cibo" %% "scalastan" % "0.5.7"
 ```
 
 Project Structure

--- a/src/main/scala/com/cibo/scalastan/CodeBuilder.scala
+++ b/src/main/scala/com/cibo/scalastan/CodeBuilder.scala
@@ -86,8 +86,9 @@ protected class CodeBuilder {
 
   private def append[T <: ScalaStan#TransformBase[_, _]](t: T, array: ArrayBuffer[T]): Unit = {
     if (!array.exists(_.name == t.name)) {
-      array.prepend(t) // Prepend so dependencies get computed first (do this first to prevent infinite recursion).
-      append(t._code)  // Add dependencies.
+      array.prepend(t)                  // Prepend to the list (to avoid infinite recursion).
+      append(t._code)                   // Add dependencies.
+      array.append(array.remove(0))     // Move this value behind its dependencies.
     }
   }
 

--- a/src/main/scala/com/cibo/scalastan/models/Horseshoe.scala
+++ b/src/main/scala/com/cibo/scalastan/models/Horseshoe.scala
@@ -76,7 +76,7 @@ case class Horseshoe(
   }
 
   // Regression coefficients.
-  val beta = new TransformedParameter(vector(p)) {
+  val beta: ParameterDeclaration[StanVector] = new TransformedParameter(vector(p)) {
     result := z *:* lambdaTilde * tau
   }
 
@@ -107,7 +107,7 @@ case class Horseshoe(
     .withData(y, ys)
 
   def predict(data: Seq[Seq[Double]], results: StanResults): Seq[Double] = {
-    val bestBeta = results.best(beta.result)
+    val bestBeta = results.best(beta)
     val bestOffset = results.best(beta0)
     data.map { vs =>
       require(vs.length == bestBeta.length)

--- a/src/test/scala/com/cibo/scalastan/TransformedParameterSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/TransformedParameterSpec.scala
@@ -42,6 +42,19 @@ class TransformedParameterSpec extends ScalaStanBaseSpec {
       }
     }
 
+    it("should output dependencies in the right order") {
+      new ScalaStan {
+        val a = new TransformedParameter(real()) {
+          result := 5
+        }
+        val b = new TransformedParameter(real()) {
+          result := a
+        }
+        val model = new Model { local(real()) := a; local(real()) := b }
+        checkCode(model, "transformed parameters { real a; real b; { a = 5; } { b = a; } }")
+      }
+    }
+
     it("should not allow assignment to data") {
       """
       new ScalaStan {

--- a/src/test/scala/com/cibo/scalastan/models/HorseshoeSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/models/HorseshoeSpec.scala
@@ -10,7 +10,7 @@ class HorseshoeSpec extends ScalaStanBaseSpec {
 
     it("generates predictions") {
       val results = hs.compile.asInstanceOf[MockCompiledModel]
-        .set[StanVector](hs.beta.result, Seq(Seq(0.5, 1.5)))
+        .set[StanVector](hs.beta, Seq(Seq(0.5, 1.5)))
         .set[StanReal](hs.beta0, Seq(2.0))
         .run()
       hs.predict(Seq(Seq(3.0, 4.0)), results) shouldBe Seq(2.0 + 0.5 * 3.0 + 1.5 * 4.0)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.7-SNAPSHOT"
+version in ThisBuild := "0.5.7"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.7"
+version in ThisBuild := "0.5.8-SNAPSHOT"


### PR DESCRIPTION
This fixes the way transformed parameter/data dependencies are handled and adds a test.  It also updates the Horseshoe model to be compatible with the one in 0.5.4.