### PR TITLE
Fix array stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ScalaStan Dependency
 To use ScalaStan, add the following to your build:
 ```scala
 resolvers += Resolver.bintrayRepo("cibotech", "public")
-libraryDependencies += "com.cibo" %% "scalastan" % "0.5.7"
+libraryDependencies += "com.cibo" %% "scalastan" % "0.5.8"
 ```
 
 Project Structure

--- a/src/main/scala/com/cibo/scalastan/StanType.scala
+++ b/src/main/scala/com/cibo/scalastan/StanType.scala
@@ -331,7 +331,7 @@ case class StanArray[CONTAINED <: StanType] private[scalastan] (
   )(
     func: Seq[Seq[Double]] => Double
   ): Seq[CONTAINED#SUMMARY_TYPE] = {
-    values.transpose.map { v =>
+    values.map(_.transpose).transpose.map { v =>
       inner.combine(v.asInstanceOf[Seq[Seq[inner.SCALA_TYPE]]])(func)
     }.toVector
   }

--- a/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
@@ -100,6 +100,10 @@ class StanResultsSpec extends ScalaStanBaseSpec {
       results.mean(TestScalaStan.v2) shouldBe Vector(1.5, 2.5, 3.5)
     }
 
+    it("returns the mean array of vectors") {
+      results.mean(TestScalaStan.v3) shouldBe Vector(Vector(311.0, 312.0), Vector(321.0, 322.0), Vector(331.0, 332.0))
+    }
+
     it("returns the mean lp") {
       results.mean(results.logPosterior) shouldBe 1.5
     }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.8"
+version in ThisBuild := "0.5.9-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.8-SNAPSHOT"
+version in ThisBuild := "0.5.8"


### PR DESCRIPTION
Summary statistics weren't being computed correctly for arrays despite showing up correctly in the "summary" output (vectors were fine).  This is because the `combine` method in `StanArray` wasn't transposing the values, so it was doing the summary along the wrong axis.  This fixes the `combine` method and adds a test.