### PR TITLE
Change results data structure and type parsers to improve memory use.

### DIFF
--- a/src/main/scala/com/cibo/scalastan/StanRunner.scala
+++ b/src/main/scala/com/cibo/scalastan/StanRunner.scala
@@ -93,17 +93,16 @@ protected object StanRunner {
       }
     }
 
-    private def readIterations(fileName: String): (Map[String, Int], Vector[Vector[String]]) = {
+    private def readIterations(fileName: String): (Vector[String], Vector[Vector[String]]) = {
       val reader = new BufferedReader(new FileReader(fileName))
       try {
         val lines = reader.lines.iterator.asScala.filterNot(_.startsWith("#")).toVector
         if (lines.nonEmpty) {
-          (
-            lines.head.split(',').zipWithIndex.toMap,
-            lines.tail.map(_.split(',').toVector)
-          )
+          val header = lines.head.split(',').toVector
+          val columns = lines.tail.map(_.split(',').toVector).transpose
+          (header, columns)
         } else {
-          (Map.empty, Vector.empty)
+          (Vector.empty, Vector.empty)
         }
       } finally {
         reader.close()
@@ -179,7 +178,8 @@ protected object StanRunner {
         }
       }.seq.toVector
 
-      StanResults(results.map(_._1).head, results.map(_._2), model)
+      val parameterChains: Map[String, Vector[Vector[String]]] = results.head._1.zip(results.map(_._2).transpose).toMap
+      StanResults(parameterChains, model)
     }
   }
 }

--- a/src/main/scala/com/cibo/scalastan/StanRunner.scala
+++ b/src/main/scala/com/cibo/scalastan/StanRunner.scala
@@ -93,16 +93,16 @@ protected object StanRunner {
       }
     }
 
-    private def readIterations(fileName: String): (Vector[String], Vector[Vector[String]]) = {
+    private def readIterations(fileName: String): Map[String, Vector[String]] = {
       val reader = new BufferedReader(new FileReader(fileName))
       try {
         val lines = reader.lines.iterator.asScala.filterNot(_.startsWith("#")).toVector
         if (lines.nonEmpty) {
           val header = lines.head.split(',').toVector
           val columns = lines.tail.map(_.split(',').toVector).transpose
-          (header, columns)
+          header.zip(columns).toMap
         } else {
-          (Vector.empty, Vector.empty)
+          Map.empty
         }
       } finally {
         reader.close()
@@ -156,7 +156,7 @@ protected object StanRunner {
           Some(readIterations(fileName))
         } else None
         cachedResults match {
-          case Some(r) if r._2.nonEmpty =>
+          case Some(r) if r.nonEmpty =>
             println(s"Found cached results: $name")
             Some(r)
           case _                     =>
@@ -178,7 +178,7 @@ protected object StanRunner {
         }
       }.seq.toVector
 
-      val parameterChains: Map[String, Vector[Vector[String]]] = results.head._1.zip(results.map(_._2).transpose).toMap
+      val parameterChains: Map[String, Vector[Vector[String]]] = results.flatten.groupBy(_._1).mapValues(_.map(_._2))
       StanResults(parameterChains, model)
     }
   }

--- a/src/test/scala/com/cibo/scalastan/ScalaStanBaseSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/ScalaStanBaseSpec.scala
@@ -50,9 +50,11 @@ trait ScalaStanBaseSpec extends FunSpec with Matchers {
       cache: Boolean,
       method: RunMethod.Method
     ): StanResults = {
-      val grouped = model.data.flatten.groupBy(_._1)
-      val (header2, values2) = grouped.mapValues(_.map{ case(k, v) => v }).unzip
-      StanResults(header2.zipWithIndex.toMap, (0 until chains).map(_ => values2.toVector.transpose).toVector, model)
+      val mappedData: Map[String, Vector[Vector[String]]] = model.data.flatten.groupBy(_._1).mapValues { grouped =>
+        val iterations = grouped.map{ case(k, v) => v }
+        Vector.fill(chains)(iterations)
+      }
+      StanResults(mappedData, model)
     }
   }
 

--- a/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
@@ -47,8 +47,10 @@ class StanResultsSpec extends ScalaStanBaseSpec {
     s"${TestScalaStan.v3.emit}.3.2" -> 332
   ).mapValues(_.toString)
 
-  val (header, values) = Seq(testData1, testData2).flatten.groupBy(_._1).mapValues(_.map{ case(k, v) => v }).unzip
-  val results = StanResults(header.zipWithIndex.toMap, Vector(values.toVector.transpose), model)
+  val mappedData: Map[String, Vector[Vector[String]]] = Seq(testData1, testData2).flatten.groupBy(_._1).mapValues(
+    grouped => Vector(grouped.map{ case(k, v) => v }.toVector)
+  )
+  val results = StanResults(mappedData, model)
 
   describe("samples") {
     it("returns all scalar samples") {


### PR DESCRIPTION
Follow-up to #69 based on suggestions from @joewing and @johndavidhahn. StanResult data was restructured to use a map at the top level (mostly to avoid bugs syncing headers to data, and to simplify some operations that retrieve entire chains). The StanType parse methods were also updated to use the new data format (rather than building a new Map for each invocation as in #69).

In the test models I used there were some small additional improvements in heap use vs RC1. The biggest improvement, however, was to runtime. RC1 dramatically increased runtime compared to v0.5.8. This version reduces runtime compared to RC1 and beats v0.5.8 by almost ~50% in my tests.