### PR TITLE
Fix imported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ScalaStan Dependency
 To use ScalaStan, add the following to your build:
 ```scala
 resolvers += Resolver.bintrayRepo("cibotech", "public")
-libraryDependencies += "com.cibo" %% "scalastan" % "0.5.8"
+libraryDependencies += "com.cibo" %% "scalastan" % "0.5.10"
 ```
 
 Project Structure

--- a/src/it/scala/com/cibo/scalastan/examples/ImportedModelExample.scala
+++ b/src/it/scala/com/cibo/scalastan/examples/ImportedModelExample.scala
@@ -28,6 +28,8 @@ object ImportedModelExample extends App with ScalaStan {
 
   val xs = Seq(1.0, 0.5, 1.5, 0.75)
   val results = model.withData(x, xs).withData(n, xs.length).run()
-  results.summary(System.out)
+  results.summary(System.out, mu, sigma)
 
 }
+
+class ImportedModelExampleSpec extends AppRunnerSpec(ImportedModelExample)

--- a/src/it/scala/com/cibo/scalastan/examples/ImportedModelExample.scala
+++ b/src/it/scala/com/cibo/scalastan/examples/ImportedModelExample.scala
@@ -1,0 +1,33 @@
+package com.cibo.scalastan.examples
+
+import com.cibo.scalastan.ScalaStan
+
+object ImportedModelExample extends App with ScalaStan {
+
+  val n = data(int(lower = 0))
+  val x = data(vector(n))
+
+  val mu = parameter(real())
+  val sigma = parameter(real(lower = 0))
+
+  val model = Model.loadFromString(
+    s"""
+        data {
+          int<lower=0> n;
+          vector[n] x;
+        }
+        parameters {
+          real mu;
+          real<lower=0> sigma;
+        }
+        model {
+          x ~ normal(mu, sigma);
+        }
+    """
+  )
+
+  val xs = Seq(1.0, 0.5, 1.5, 0.75)
+  val results = model.withData(x, xs).withData(n, xs.length).run()
+  results.summary(System.out)
+
+}

--- a/src/main/scala/com/cibo/scalastan/CompiledModel.scala
+++ b/src/main/scala/com/cibo/scalastan/CompiledModel.scala
@@ -45,6 +45,7 @@ abstract class CompiledModel {
     decl: StanDataDeclaration[T],
     data: V
   )(implicit ev: V <:< T#SCALA_TYPE): CompiledModel = {
+    model._code.append(decl)
     val conv = data.asInstanceOf[T#SCALA_TYPE]
 
     // Check if this parameter has already been assigned and throw an exception if the values are conflicting.

--- a/src/main/scala/com/cibo/scalastan/CompiledModel.scala
+++ b/src/main/scala/com/cibo/scalastan/CompiledModel.scala
@@ -23,11 +23,8 @@ abstract class CompiledModel {
   protected def runChecked(chains: Int, seed: Int, cache: Boolean, method: RunMethod.Method): StanResults
 
   private[scalastan] final def emitData(writer: Writer): Unit = {
-    model.program.data.foreach { value =>
-      val mapping = dataMapping.getOrElse(value.emit,
-        throw new IllegalStateException(s"no data provided for ${value.emit}")
-      )
-      writer.write(mapping.emit)
+    dataMapping.values.foreach { value =>
+      writer.write(value.emit)
       writer.write("\n")
     }
   }
@@ -45,7 +42,6 @@ abstract class CompiledModel {
     decl: StanDataDeclaration[T],
     data: V
   )(implicit ev: V <:< T#SCALA_TYPE): CompiledModel = {
-    model._code.append(decl)
     val conv = data.asInstanceOf[T#SCALA_TYPE]
 
     // Check if this parameter has already been assigned and throw an exception if the values are conflicting.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.10"
+version in ThisBuild := "0.5.11-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.10-SNAPSHOT"
+version in ThisBuild := "0.5.10"


### PR DESCRIPTION
We were only exporting data that was actually referenced in the model to Stan.  This causes a problem with imported models since we don't know which values are referenced.  So this makes it so we export everything that was specified (which is the way it used to work at some point).  This also adds an integration test to make sure we can run imported models.

Note that the check that used to be performed to ensure we output everything the program referenced still exists in `CompiledModel.run` (the check here was a duplicate).