### PR TITLE
Expose models so that .emit() can be called

### DIFF
--- a/src/main/scala/com/cibo/scalastan/models/Horseshoe.scala
+++ b/src/main/scala/com/cibo/scalastan/models/Horseshoe.scala
@@ -85,7 +85,7 @@ case class Horseshoe(
     result := beta0 + x * beta
   }
 
-  private val model = new Model {
+  val model = new Model {
     sigma ~ stan.cauchy(0, 1)
     z ~ stan.normal(0, 1)
     aux1Local ~ stan.normal(0, 1)

--- a/src/main/scala/com/cibo/scalastan/models/LinearRegression.scala
+++ b/src/main/scala/com/cibo/scalastan/models/LinearRegression.scala
@@ -28,7 +28,7 @@ case class LinearRegression(
   val beta: ParameterDeclaration[StanVector] = parameter(vector(p))         // Coefficients
   val sigma: ParameterDeclaration[StanReal] = parameter(real(lower = 0))    // Error
 
-  private val model = new Model {
+  val model = new Model {
     sigma ~ stan.cauchy(0, 1)
     y ~ stan.normal(x * beta + beta0, sigma)
   }


### PR DESCRIPTION
Removes `private` from the models in Horseshoe and LinearRegression so that .emit() can be called externally in other projects.