### PR TITLE
Move GeneratedQuantity to ScalaStan#Model.

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,13 +247,17 @@ val myFunc = new Function(vector(n)) {
 Generated Quantities
 --------------------
 Generated quantities provide a means of deriving quantities from parameters, data, and random number generation.
-In ScalaStan, such quantities are created by extending the `GeneratedQuantity` class. This class works like
-the data and parameter transform blocks.  In addition to parameters and data, a generated quantity can use
-random numbers drawn from a distribution.
+In ScalaStan, such quantities are created by extending the `GeneratedQuantity` class for a model. This class
+works like the data and parameter transform blocks, but is contained in the model.  In addition to parameters and
+data, a generated quantity can use random numbers drawn from a distribution.
 
 Here is an example to draw a random number:
 ```scala
-val rand = new GeneratedQuantity(real()) {
+val myModel = new Model {
+  // ...
+}
+
+val rand = new myModel.GeneratedQuantity(real()) {
   result := stan.normal(0.0, 1.0).rng
 }
 ```

--- a/src/it/scala/com/cibo/scalastan/examples/LotkaVolterraExample.scala
+++ b/src/it/scala/com/cibo/scalastan/examples/LotkaVolterraExample.scala
@@ -57,15 +57,16 @@ object LotkaVolterraExample extends App with ScalaStan {
         y(i, k) ~ stan.lognormal(stan.log(z(i, k)), sigma)
       }
     }
+
   }
 
-  val y0_rep = new GeneratedQuantity(real()(2)) {
+  val y0_rep = new model.GeneratedQuantity(real()(2)) {
     for (k <- range(1, 2)) {
       result(k) := stan.lognormal(stan.log(z0(k)), sigma(k)).rng
     }
   }
 
-  val y_rep = new GeneratedQuantity(real()(N, 2)) {
+  val y_rep = new model.GeneratedQuantity(real()(N, 2)) {
     for (k <- range(1, 2)) {
       for (n <- range(1, N)) {
         result(n, k) := stan.lognormal(stan.log(z(n, k)), sigma(k)).rng

--- a/src/main/scala/com/cibo/scalastan/CodeBuilder.scala
+++ b/src/main/scala/com/cibo/scalastan/CodeBuilder.scala
@@ -26,7 +26,7 @@ protected class CodeBuilder {
   private val functions = ArrayBuffer[ScalaStan#Function[_]]()
   private val transformedData = ArrayBuffer[ScalaStan#TransformedData[_]]()
   private val transformedParameters = ArrayBuffer[ScalaStan#TransformedParameter[_]]()
-  private val generatedQuantities = ArrayBuffer[ScalaStan#GeneratedQuantity[_]]()
+  private val generatedQuantities = ArrayBuffer[ScalaStan#Model#GeneratedQuantity[_]]()
 
   // Create the top-level scope.
   stack += ArrayBuffer()
@@ -95,7 +95,7 @@ protected class CodeBuilder {
   def append(f: ScalaStan#Function[_]): Unit = append(f, functions)
   def append(t: ScalaStan#TransformedData[_]): Unit = append(t, transformedData)
   def append(t: ScalaStan#TransformedParameter[_]): Unit = append(t, transformedParameters)
-  def append(g: ScalaStan#GeneratedQuantity[_]): Unit = append(g, generatedQuantities)
+  def append(g: ScalaStan#Model#GeneratedQuantity[_]): Unit = append(g, generatedQuantities)
 
   def append(s: StanStatement): Unit = {
     require(stack.nonEmpty)

--- a/src/main/scala/com/cibo/scalastan/ScalaStan.scala
+++ b/src/main/scala/com/cibo/scalastan/ScalaStan.scala
@@ -34,12 +34,6 @@ trait ScalaStan extends Implicits { ss =>
 
   protected implicit val _scalaStan: ScalaStan = this
 
-  // Generated quantities aren't referenced from the model, so we need some way to cause them
-  // to be generated.  For now, we simply generate all generated quantities.
-  // In the future maybe generated quantity code should be moved inside the model so that we
-  // can associate it with the model more easily?
-  private val generatedQuantities: ArrayBuffer[GeneratedQuantity[_]] = new ArrayBuffer[GeneratedQuantity[_]]()
-
   private var idCounter: Int = 0
 
   private[scalastan] def nextId: Int = {
@@ -115,20 +109,6 @@ trait ScalaStan extends Implicits { ss =>
   def choleskyFactorCov(
     dim: StanValue[StanInt]
   ): StanMatrix = StanMatrix(dim, dim, constraint = MatrixConstraint.CholeskyFactorCov)
-
-  implicit def compile[M <: CompiledModel](model: Model)(implicit runner: StanRunner[M]): CompiledModel = model.compile
-
-  implicit def dataTransform2Value[T <: StanType](transform: TransformedData[T]): StanLocalDeclaration[T] = {
-    transform.result
-  }
-
-  implicit def paramTransform2Value[T <: StanType](transform: TransformedParameter[T]): ParameterDeclaration[T] = {
-    transform.result
-  }
-
-  implicit def generatedQuntity2Value[T <: StanType](quantity: GeneratedQuantity[T]): ParameterDeclaration[T] = {
-    quantity.result
-  }
 
   trait StanCode {
 
@@ -263,22 +243,29 @@ trait ScalaStan extends Implicits { ss =>
     private[scalastan] lazy val generate: StanTransformedParameter = StanTransformedParameter(result, _code.results)
   }
 
-  abstract class GeneratedQuantity[T <: StanType](typeConstructor: T) extends TransformBase[T, StanParameterDeclaration[T]] {
-    lazy val result: StanParameterDeclaration[T] = {
-      if (!generatedQuantities.exists(_.name == name)) {
-        generatedQuantities += this
-      }
-      StanParameterDeclaration[T](typeConstructor, () => _userName, owner = Some(this))
-    }
-    protected implicit val _generatedQuantity: InGeneratedQuantityBlock = InGeneratedQuantityBlock
-
-    private[scalastan] def export(builder: CodeBuilder): Unit = builder.append(this)
-
-    private[scalastan] lazy val generate: StanGeneratedQuantity = StanGeneratedQuantity(result, _code.results)
-  }
-
   /** Trait providing the Stan Model DSL. */
   trait Model extends StanCode {
+
+    // Generated quantities aren't referenced from the model, so we need some way to cause them
+    // to be generated.  To deal with this, generated quantities are created inside the model
+    // so that we can track them and generate them when the model is generated.
+    private val generatedQuantities: ArrayBuffer[GeneratedQuantity[_]] = new ArrayBuffer[GeneratedQuantity[_]]()
+
+    abstract class GeneratedQuantity[T <: StanType](
+      typeConstructor: T
+    ) extends TransformBase[T, StanParameterDeclaration[T]] {
+      lazy val result: StanParameterDeclaration[T] = {
+        if (!generatedQuantities.exists(_.name == name)) {
+          generatedQuantities += this
+        }
+        StanParameterDeclaration[T](typeConstructor, () => _userName, owner = Some(this))
+      }
+      protected implicit val _generatedQuantity: InGeneratedQuantityBlock = InGeneratedQuantityBlock
+
+      private[scalastan] def export(builder: CodeBuilder): Unit = builder.append(this)
+
+      private[scalastan] lazy val generate: StanGeneratedQuantity = StanGeneratedQuantity(result, _code.results)
+    }
 
     // Log probability function.
     final protected def target: StanTargetValue = StanTargetValue()
@@ -353,6 +340,20 @@ trait ScalaStan extends Implicits { ss =>
 
     def compile[M <: CompiledModel](implicit runner: StanRunner[M]): CompiledModel =
       TransformedModel(this).compile(runner)
+  }
+
+  implicit def compile[M <: CompiledModel](model: Model)(implicit runner: StanRunner[M]): CompiledModel = model.compile
+
+  implicit def dataTransform2Value[T <: StanType](transform: TransformedData[T]): StanLocalDeclaration[T] = {
+    transform.result
+  }
+
+  implicit def paramTransform2Value[T <: StanType](transform: TransformedParameter[T]): ParameterDeclaration[T] = {
+    transform.result
+  }
+
+  implicit def generatedQuantity2Value[T <: StanType](quantity: Model#GeneratedQuantity[T]): ParameterDeclaration[T] = {
+    quantity.result
   }
 
   case class TransformedModel private (

--- a/src/test/scala/com/cibo/scalastan/GeneratedQuantitySpec.scala
+++ b/src/test/scala/com/cibo/scalastan/GeneratedQuantitySpec.scala
@@ -4,9 +4,10 @@ class GeneratedQuantitySpec extends ScalaStanBaseSpec {
   describe("GeneratedQuantity") {
     it("should allow assignment to the result") {
       new ScalaStan {
-        val model = new Model { }
-        val t = new GeneratedQuantity(real()) {
-          result := 5
+        val model = new Model {
+          val t = new GeneratedQuantity(real()) {
+            result := 5
+          }
         }
         checkCode(model, "generated quantities { real t; { t = 5; } }")
       }

--- a/src/test/scala/com/cibo/scalastan/ast/StanNodeSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/ast/StanNodeSpec.scala
@@ -60,7 +60,10 @@ class StanNodeSpec extends ScalaStanBaseSpec with ScalaStan {
     }
 
     it("should allow rng in a generated quantity") {
-      val gen = new GeneratedQuantity(real()) { stan.normal(v1, v2).rng }
+      val model = new Model {}
+      val gen = new model.GeneratedQuantity(real()) {
+        stan.normal(v1, v2).rng
+      }
     }
 
     it("should not allow rng in a model") {
@@ -68,7 +71,10 @@ class StanNodeSpec extends ScalaStanBaseSpec with ScalaStan {
     }
 
     it("should allow rng with addition") {
-      val gen = new GeneratedQuantity(real()) { result := result + stan.normal(v1, v2).rng }
+      val model = new Model {}
+      val gen = new model.GeneratedQuantity(real()) {
+        result := result + stan.normal(v1, v2).rng
+      }
     }
   }
 }


### PR DESCRIPTION
This change moves the `GeneratedQuantity` class to `ScalaStan#Model`.  The motivation for this is to allow generated quantities to be easily associated with the model.  Since generated quantities don't necessarily reference anything from the model, without something like this there is no way to associate a generated quantity with a model.  To deal with this, the we used to keep a mutable value in the `ScalaStan` trait, but that method breaks down if there are multiple `Model`s.

This will be a breaking change for anything that uses generated quantities.  Something like this:
```scala
val x = new GeneratedQuantity(real()) { ... }
```

will need to be converted to:
```scala
val x = new model.GeneratedQuantity(real()) { ... }
```

where `model` is the instance of `ScalaStan#Model`.

For #63.