### PR TITLE
Better bounds

### DIFF
--- a/src/main/scala/com/cibo/scalastan/Implicits.scala
+++ b/src/main/scala/com/cibo/scalastan/Implicits.scala
@@ -30,8 +30,6 @@ protected trait Implicits {
   implicit def doubleLiteral2optReal(value: Double): Option[StanConstant[StanReal]] =
     Some(StanConstant[StanReal](StanReal(), value))
 
-  implicit def stanValue2optValue[T <: StanType](value: StanValue[T]): Option[StanValue[T]] = Some(value)
-
   implicit def seq2array[T <: StanType](values: Seq[StanValue[T]]): StanValue[StanArray[T]] =
     StanArrayLiteral[T, StanArray[T]](values)
 }

--- a/src/main/scala/com/cibo/scalastan/ScalaStan.scala
+++ b/src/main/scala/com/cibo/scalastan/ScalaStan.scala
@@ -80,23 +80,28 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
     StanParameterDeclaration[T](typeConstructor, fixName(name.value))
   }
 
+  private def boundOpt[T <: StanType](bound: StanValue[T]): Option[StanValue[T]] = bound match {
+    case _: StanUnknown[T] => None
+    case _                 => Some(bound)
+  }
+
   def int(
-    lower: Option[StanValue[StanInt]] = None,
-    upper: Option[StanValue[StanInt]] = None
-  ): StanInt = StanInt(lower, upper)
+    lower: StanValue[StanInt] = StanUnknownInt,
+    upper: StanValue[StanInt] = StanUnknownInt
+  ): StanInt = StanInt(boundOpt(lower), boundOpt(upper))
 
   def categorical(): StanCategorical = StanCategorical()
 
   def real(
-    lower: Option[StanValue[StanReal]] = None,
-    upper: Option[StanValue[StanReal]] = None
-  ): StanReal = StanReal(lower, upper)
+    lower: StanValue[StanReal] = StanUnknownReal,
+    upper: StanValue[StanReal] = StanUnknownReal
+  ): StanReal = StanReal(boundOpt(lower), boundOpt(upper))
 
   def vector(
     dim: StanValue[StanInt],
-    lower: Option[StanValue[StanReal]] = None,
-    upper: Option[StanValue[StanReal]] = None
-  ): StanVector = StanVector(dim, lower, upper)
+    lower: StanValue[StanReal] = StanUnknownReal,
+    upper: StanValue[StanReal] = StanUnknownReal
+  ): StanVector = StanVector(dim, boundOpt(lower), boundOpt(upper))
 
   def simplex(dim: StanValue[StanInt]): StanVector =
     StanVector(dim, constraint = VectorConstraint.Simplex)
@@ -112,16 +117,16 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
 
   def rowVector(
     dim: StanValue[StanInt],
-    lower: Option[StanValue[StanReal]] = None,
-    upper: Option[StanValue[StanReal]] = None
-  ): StanRowVector = StanRowVector(dim, lower, upper)
+    lower: StanValue[StanReal] = StanUnknownReal,
+    upper: StanValue[StanReal] = StanUnknownReal
+  ): StanRowVector = StanRowVector(dim, boundOpt(lower), boundOpt(upper))
 
   def matrix(
     rows: StanValue[StanInt],
     cols: StanValue[StanInt],
-    lower: Option[StanValue[StanReal]] = None,
-    upper: Option[StanValue[StanReal]] = None
-  ): StanMatrix = StanMatrix(rows, cols, lower, upper)
+    lower: StanValue[StanReal] = StanUnknownReal,
+    upper: StanValue[StanReal] = StanUnknownReal
+  ): StanMatrix = StanMatrix(rows, cols, boundOpt(lower), boundOpt(upper))
 
   def corrMatrix(
     dim: StanValue[StanInt]

--- a/src/main/scala/com/cibo/scalastan/ScalaStan.scala
+++ b/src/main/scala/com/cibo/scalastan/ScalaStan.scala
@@ -80,28 +80,23 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
     StanParameterDeclaration[T](typeConstructor, fixName(name.value))
   }
 
-  private def boundOpt[T <: StanType](bound: StanValue[T]): Option[StanValue[T]] = bound match {
-    case _: StanUnknown[T] => None
-    case _                 => Some(bound)
-  }
-
   def int(
     lower: StanValue[StanInt] = StanUnknownInt,
     upper: StanValue[StanInt] = StanUnknownInt
-  ): StanInt = StanInt(boundOpt(lower), boundOpt(upper))
+  ): StanInt = StanInt(StanUnknown.boundOpt(lower), StanUnknown.boundOpt(upper))
 
   def categorical(): StanCategorical = StanCategorical()
 
   def real(
     lower: StanValue[StanReal] = StanUnknownReal,
     upper: StanValue[StanReal] = StanUnknownReal
-  ): StanReal = StanReal(boundOpt(lower), boundOpt(upper))
+  ): StanReal = StanReal(StanUnknown.boundOpt(lower), StanUnknown.boundOpt(upper))
 
   def vector(
     dim: StanValue[StanInt],
     lower: StanValue[StanReal] = StanUnknownReal,
     upper: StanValue[StanReal] = StanUnknownReal
-  ): StanVector = StanVector(dim, boundOpt(lower), boundOpt(upper))
+  ): StanVector = StanVector(dim, StanUnknown.boundOpt(lower), StanUnknown.boundOpt(upper))
 
   def simplex(dim: StanValue[StanInt]): StanVector =
     StanVector(dim, constraint = VectorConstraint.Simplex)
@@ -119,14 +114,14 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
     dim: StanValue[StanInt],
     lower: StanValue[StanReal] = StanUnknownReal,
     upper: StanValue[StanReal] = StanUnknownReal
-  ): StanRowVector = StanRowVector(dim, boundOpt(lower), boundOpt(upper))
+  ): StanRowVector = StanRowVector(dim, StanUnknown.boundOpt(lower), StanUnknown.boundOpt(upper))
 
   def matrix(
     rows: StanValue[StanInt],
     cols: StanValue[StanInt],
     lower: StanValue[StanReal] = StanUnknownReal,
     upper: StanValue[StanReal] = StanUnknownReal
-  ): StanMatrix = StanMatrix(rows, cols, boundOpt(lower), boundOpt(upper))
+  ): StanMatrix = StanMatrix(rows, cols, StanUnknown.boundOpt(lower), StanUnknown.boundOpt(upper))
 
   def corrMatrix(
     dim: StanValue[StanInt]

--- a/src/main/scala/com/cibo/scalastan/StanFunctions.scala
+++ b/src/main/scala/com/cibo/scalastan/StanFunctions.scala
@@ -497,7 +497,7 @@ protected trait StanFunctions {
   def to_array_1d[T <: StanCompoundType](
     v: StanValue[T]
   ): StanValue[StanArray[v.returnType.ELEMENT_TYPE]] =
-    StanCall[StanArray[v.returnType.ELEMENT_TYPE]](StanArray(StanUnknownDim(), v.returnType.element), "to_array_1d", Seq(v))
+    StanCall[StanArray[v.returnType.ELEMENT_TYPE]](StanArray(StanUnknownInt, v.returnType.element), "to_array_1d", Seq(v))
 
   // ODE Solvers (45).
   def integrate_ode_rk45[T <: StanScalarType](

--- a/src/main/scala/com/cibo/scalastan/StanType.scala
+++ b/src/main/scala/com/cibo/scalastan/StanType.scala
@@ -10,7 +10,7 @@
 
 package com.cibo.scalastan
 
-import com.cibo.scalastan.ast.{StanUnknownDim, StanValue}
+import com.cibo.scalastan.ast.{StanUnknownInt, StanValue}
 
 sealed trait StanType {
 
@@ -148,7 +148,7 @@ sealed trait StanType {
     lower.forall(_.isDerivedFromData) && upper.forall(_.isDerivedFromData) && getIndices.forall(_.isDerivedFromData)
 
   def apply(): StanArray[THIS_TYPE] = {
-    StanArray(StanUnknownDim(), this.asInstanceOf[THIS_TYPE])
+    StanArray(StanUnknownInt, this.asInstanceOf[THIS_TYPE])
   }
 
   def apply(
@@ -315,8 +315,8 @@ case class StanArray[CONTAINED <: StanType](
   def element: ELEMENT_TYPE = inner.element
   def realType: REAL_TYPE = StanArray(dim, inner.realType)
 
-  override def emitDims: Seq[String] = dim.map(_.emit).getOrElse("") +: inner.emitDims
-  override def getIndices: Seq[StanValue[StanInt]] = dim.get +: inner.getIndices
+  override def emitDims: Seq[String] = dim.emit +: inner.emitDims
+  override def getIndices: Seq[StanValue[StanInt]] = dim +: inner.getIndices
   def typeName: String = inner.typeName
   def getData(data: SCALA_TYPE): Seq[String] =
     data.map(d => inner.getData(d.asInstanceOf[inner.SCALA_TYPE])).transpose.flatten

--- a/src/main/scala/com/cibo/scalastan/ast/StanDistribution.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanDistribution.scala
@@ -47,8 +47,8 @@ case class StanContinuousDistribution[T <: StanType, R <: StanType](
   name: String,
   rngType: R,
   args: Seq[StanValue[_ <: StanType]],
-  lowerOpt: Option[StanValue[R]] = None,
-  upperOpt: Option[StanValue[R]] = None,
+  lowerOpt: Option[StanValue[StanReal]] = None,
+  upperOpt: Option[StanValue[StanReal]] = None,
   id: Int = StanNode.getNextId
 ) extends StanDistribution[T, R] {
   def lpdf(y: StanValue[T]): StanValue[StanReal] = StanDistributionNode(s"${name}_lpdf", y, "|", args)
@@ -56,11 +56,11 @@ case class StanContinuousDistribution[T <: StanType, R <: StanType](
   def lcdf(y: StanValue[T]): StanValue[StanReal] = StanDistributionNode(s"${name}_lcdf", y, "|", args)
   def lccdf(y: StanValue[T]): StanValue[StanReal] = StanDistributionNode(s"${name}_lccdf", y, "|", args)
   def truncate(
-    lower: Option[StanValue[R]] = None,
-    upper: Option[StanValue[R]] = None
+    lower: StanValue[StanReal] = StanUnknownReal,
+    upper: StanValue[StanReal] = StanUnknownReal
   ): StanContinuousDistribution[T, R] = {
     require(lowerOpt.isEmpty && upperOpt.isEmpty, "Distribution already truncated")
-    StanContinuousDistribution(name, rngType, args, lowerOpt = lower, upperOpt = upper)
+    copy(lowerOpt = StanUnknown.boundOpt(lower), upperOpt = StanUnknown.boundOpt(upper))
   }
   def rng(implicit gen: RngAvailable): StanCall[R] = StanCall(rngType, s"${name}_rng", args)
 }
@@ -79,16 +79,16 @@ case class StanDiscreteDistributionWithoutCdf[T <: StanType, R <: StanType] priv
   name: String,
   rngType: R,
   args: Seq[StanValue[_ <: StanType]],
-  lowerOpt: Option[StanValue[R]] = None,
-  upperOpt: Option[StanValue[R]] = None,
+  lowerOpt: Option[StanValue[StanInt]] = None,
+  upperOpt: Option[StanValue[StanInt]] = None,
   id: Int = StanNode.getNextId
 ) extends StanDiscreteDistribution[T, R] {
   def truncate(
-    lower: Option[StanValue[R]] = None,
-    upper: Option[StanValue[R]] = None
+    lower: StanValue[StanInt] = StanUnknownInt,
+    upper: StanValue[StanInt] = StanUnknownInt
   ): StanDiscreteDistributionWithoutCdf[T, R] = {
     require(lowerOpt.isEmpty && upperOpt.isEmpty, "Distribution already truncated")
-    StanDiscreteDistributionWithoutCdf(name, rngType, args, lowerOpt = lower, upperOpt = upper)
+    copy(lowerOpt = StanUnknown.boundOpt(lower), upperOpt = StanUnknown.boundOpt(upper))
   }
 }
 
@@ -96,19 +96,19 @@ case class StanDiscreteDistributionWithCdf[T <: StanType, R <: StanType] private
   name: String,
   rngType: R,
   args: Seq[StanValue[_ <: StanType]],
-  lowerOpt: Option[StanValue[T]] = None,
-  upperOpt: Option[StanValue[T]] = None,
+  lowerOpt: Option[StanValue[StanInt]] = None,
+  upperOpt: Option[StanValue[StanInt]] = None,
   id: Int = StanNode.getNextId
 ) extends StanDiscreteDistribution[T, R] {
   def cdf(y: StanValue[T]): StanValue[StanReal] = StanDistributionNode(s"${name}_cdf", y, ",", args)
   def lcdf(y: StanValue[T]): StanValue[StanReal] = StanDistributionNode(s"${name}_lcdf", y, "|", args)
   def lccdf(y: StanValue[T]): StanValue[StanReal] = StanDistributionNode(s"${name}_lccdf", y, "|", args)
   def truncate(
-    lower: Option[StanValue[T]] = None,
-    upper: Option[StanValue[T]] = None
+    lower: StanValue[StanInt] = StanUnknownInt,
+    upper: StanValue[StanInt] = StanUnknownInt
   ): StanDiscreteDistributionWithCdf[T, R] = {
     require(lowerOpt.isEmpty && upperOpt.isEmpty, "Distribution already truncated")
-    StanDiscreteDistributionWithCdf(name, rngType, args, lowerOpt = lower, upperOpt = upper)
+    copy(lowerOpt = StanUnknown.boundOpt(lower), upperOpt = StanUnknown.boundOpt(upper))
   }
 }
 

--- a/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
@@ -452,14 +452,25 @@ case class StanLiteral(
   def emit: String = value.toString
 }
 
-case class StanUnknownDim(
-  id: Int = StanNode.getNextId
-) extends StanValue[StanInt] {
-  val returnType: StanInt = StanInt()
+sealed trait StanUnknown[T <: StanType] extends StanValue[T] {
+  val id: Int = StanNode.getNextId
   def inputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = Seq.empty
   def isDerivedFromData: Boolean = true
   def export(builder: CodeBuilder): Unit = ()
   def emit: String = ""
+}
+
+case object StanUnknownInt extends StanUnknown[StanInt] {
+  val returnType: StanInt = StanInt(None, None)
+}
+
+case object StanUnknownReal extends StanUnknown[StanReal] {
+  val returnType: StanReal = StanReal(None, None)
+}
+
+object StanUnknown {
+  implicit val unknownInt: StanUnknown[StanInt] = StanUnknownInt
+  implicit val unknownReal: StanUnknown[StanReal] = StanUnknownReal
 }

--- a/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
@@ -471,6 +471,8 @@ case object StanUnknownReal extends StanUnknown[StanReal] {
 }
 
 object StanUnknown {
-  implicit val unknownInt: StanUnknown[StanInt] = StanUnknownInt
-  implicit val unknownReal: StanUnknown[StanReal] = StanUnknownReal
+  def boundOpt[T <: StanType](v: StanValue[T]): Option[StanValue[T]] = v match {
+    case _: StanUnknown[T] => None
+    case _                 => v
+  }
 }

--- a/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
@@ -473,6 +473,6 @@ case object StanUnknownReal extends StanUnknown[StanReal] {
 object StanUnknown {
   def boundOpt[T <: StanType](v: StanValue[T]): Option[StanValue[T]] = v match {
     case _: StanUnknown[T] => None
-    case _                 => v
+    case _                 => Some(v)
   }
 }

--- a/src/main/scala/com/cibo/scalastan/models/Horseshoe.scala
+++ b/src/main/scala/com/cibo/scalastan/models/Horseshoe.scala
@@ -28,30 +28,30 @@ case class Horseshoe(
   // Shrinkage Priors", 2017.
   // This code is adapted from section C.2.
 
-  private val n = data(int(lower = 0))    // Number of observations
-  private val p = data(int(lower = 0))    // Number of parameters
+  val n: DataDeclaration[StanInt] = data(int(lower = 0))    // Number of observations
+  val p: DataDeclaration[StanInt] = data(int(lower = 0))    // Number of parameters
 
-  private val x: DataDeclaration[StanMatrix] = data(matrix(n, p))   // Inputs
-  private val y: DataDeclaration[StanVector] = data(vector(n))      // Outputs
+  val x: DataDeclaration[StanMatrix] = data(matrix(n, p))   // Inputs
+  val y: DataDeclaration[StanVector] = data(vector(n))      // Outputs
 
   // Priors
-  private val scaleIntercept = data(real(lower = 0))
-  private val nuLocal = data(real(lower = 1))
-  private val nuGlobal = data(real(lower = 1))
-  private val slabScale = data(real(lower = 0))
-  private val slabDf = data(real(lower = 0))
+  val scaleIntercept: DataDeclaration[StanReal] = data(real(lower = 0.0))
+  val nuLocal: DataDeclaration[StanReal] = data(real(lower = 1.0))
+  val nuGlobal: DataDeclaration[StanReal] = data(real(lower = 1.0))
+  val slabScale: DataDeclaration[StanReal] = data(real(lower = 0.0))
+  val slabDf: DataDeclaration[StanReal] = data(real(lower = 0.0))
 
   val beta0: ParameterDeclaration[StanReal] = parameter(real())   // y-intercept
-  val sigma: ParameterDeclaration[StanReal] = parameter(real(lower = 0))            // Noise standard deviation
+  val sigma: ParameterDeclaration[StanReal] = parameter(real(lower = 0.0)) // Noise standard deviation
   
   val z: ParameterDeclaration[StanVector] = parameter(vector(p))
-  private val aux1Global = parameter(real(lower = 0))
-  private val aux2Global = parameter(real(lower = 0))
-  private val aux1Local = parameter(vector(p, lower = 0))
-  private val aux2Local = parameter(vector(p, lower = 0))
-  private val caux = parameter(real(lower = 0))
+  private val aux1Global = parameter(real(lower = 0.0))
+  private val aux2Global = parameter(real(lower = 0.0))
+  private val aux1Local = parameter(vector(p, lower = 0.0))
+  private val aux2Local = parameter(vector(p, lower = 0.0))
+  private val caux = parameter(real(lower = 0.0))
 
-  private val tau0 = new TransformedData(real(lower = 0)) {
+  private val tau0 = new TransformedData(real(lower = 0.0)) {
     result := stan.fmin(p0, p - 1) / (p - stan.fmin(p0, p - 1)) / stan.pow(n, 0.5)
   }
 

--- a/src/main/scala/com/cibo/scalastan/models/Horseshoe.scala
+++ b/src/main/scala/com/cibo/scalastan/models/Horseshoe.scala
@@ -44,7 +44,7 @@ case class Horseshoe(
   val beta0: ParameterDeclaration[StanReal] = parameter(real())   // y-intercept
   val sigma: ParameterDeclaration[StanReal] = parameter(real(lower = 0))            // Noise standard deviation
   
-  private val z = parameter(vector(p))
+  val z: ParameterDeclaration[StanVector] = parameter(vector(p))
   private val aux1Global = parameter(real(lower = 0))
   private val aux2Global = parameter(real(lower = 0))
   private val aux1Local = parameter(vector(p, lower = 0))
@@ -56,22 +56,22 @@ case class Horseshoe(
   }
 
   // Global shrinkage parameter.
-  private val tau = new TransformedParameter(real(lower = 0)) {
+  val tau: ParameterDeclaration[StanReal] = new TransformedParameter(real(lower = 0)) {
     result := aux1Global * stan.sqrt(aux2Global) * tau0 * sigma
   }
 
   // Slab scale.
-  private val c = new TransformedParameter(real(lower = 0)) {
+  val c: ParameterDeclaration[StanReal] = new TransformedParameter(real(lower = 0)) {
     result := slabScale * stan.sqrt(caux)
   }
 
   // Local shrinkage parameter.
-  private val lambda = new TransformedParameter(vector(p, lower = 0)) {
+  val lambda: ParameterDeclaration[StanVector] = new TransformedParameter(vector(p, lower = 0)) {
     result := aux1Local *:* stan.sqrt(aux2Local)
   }
 
   // "Truncated" local shrinkage parameter.
-  private val lambdaTilde = new TransformedParameter(vector(p, lower = 0)) {
+  val lambdaTilde: ParameterDeclaration[StanVector] = new TransformedParameter(vector(p, lower = 0)) {
     result := stan.sqrt((c ^ 2) * stan.square(lambda) /:/ ((c ^ 2) + (tau ^ 2) * stan.square(lambda)))
   }
 
@@ -81,11 +81,11 @@ case class Horseshoe(
   }
 
   // Latent function values.
-  private val f = new TransformedParameter(vector(n)) {
+  val f: ParameterDeclaration[StanVector] = new TransformedParameter(vector(n)) {
     result := beta0 + x * beta
   }
 
-  val model = new Model {
+  val model: Model = new Model {
     sigma ~ stan.cauchy(0, 1)
     z ~ stan.normal(0, 1)
     aux1Local ~ stan.normal(0, 1)

--- a/src/main/scala/com/cibo/scalastan/models/LinearRegression.scala
+++ b/src/main/scala/com/cibo/scalastan/models/LinearRegression.scala
@@ -28,7 +28,7 @@ case class LinearRegression(
   val beta: ParameterDeclaration[StanVector] = parameter(vector(p))         // Coefficients
   val sigma: ParameterDeclaration[StanReal] = parameter(real(lower = 0))    // Error
 
-  val model = new Model {
+  val model: Model = new Model {
     sigma ~ stan.cauchy(0, 1)
     y ~ stan.normal(x * beta + beta0, sigma)
   }

--- a/src/main/scala/com/cibo/scalastan/models/SoftKMeans.scala
+++ b/src/main/scala/com/cibo/scalastan/models/SoftKMeans.scala
@@ -31,7 +31,7 @@ case class SoftKMeans(
     result := -stan.log(k)
   }
 
-  val softZ = new TransformedParameter(real(upper = 0)(n, k)) {
+  val softZ: ParameterDeclaration[StanArray[StanArray[StanReal]]] = new TransformedParameter(real(upper = 0)(n, k)) {
     for (i <- range(1, n)) {
       for (j <- range(1, k)) {
         result(i, j) := negLogK - 0.5 * stan.dot_self(mu(j) - y(i))
@@ -39,7 +39,7 @@ case class SoftKMeans(
     }
   }
 
-  private val model = new Model {
+  val model: Model = new Model {
     // Prior
     for (i <- range(1, k)) {
       mu(i) ~ stan.normal(0, 1)
@@ -56,6 +56,6 @@ case class SoftKMeans(
     .withData(y, observations)
 
   def clusterAssignments(results: StanResults): Seq[Int] = {
-    results.best(softZ.result).map(_.zipWithIndex.maxBy(_._1)._2)
+    results.best(softZ).map(_.zipWithIndex.maxBy(_._1)._2)
   }
 }

--- a/src/main/scala/com/cibo/scalastan/transform/StanTransform.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/StanTransform.scala
@@ -199,15 +199,15 @@ abstract class StanTransform[STATE](implicit ss: ScalaStan) {
     case dn: StanDistributionNode[_] => handleDistributionNode(dn)
     case un: StanUnaryOperator[_, T] => handleUnaryOperator(un)
     case bn: StanBinaryOperator[T, _, _] => handleBinaryOperator(bn)
-    case in: StanIndexOperator[_, T, _] => handleIndexOperator(in)
-    case sl: StanSliceOperator[T, _] => handleSliceOperator(sl)
-    case tr: StanTranspose[_, T] => handleTranspose(tr)
-    case vr: StanDeclaration[T] => handleVariable(vr)
-    case cn: StanConstant[T] => handleConstant(cn)
-    case ar: StanArrayLiteral[_, _] => handleArray(ar)
-    case st: StanStringLiteral => handleString(st)
-    case lt: StanLiteral => handleLiteral(lt)
-    case ud: StanUnknownDim => handleUnknownDim(ud)
+    case in: StanIndexOperator[_, T, _]  => handleIndexOperator(in)
+    case sl: StanSliceOperator[T, _]     => handleSliceOperator(sl)
+    case tr: StanTranspose[_, T]         => handleTranspose(tr)
+    case vr: StanDeclaration[T]          => handleVariable(vr)
+    case cn: StanConstant[T]             => handleConstant(cn)
+    case ar: StanArrayLiteral[_, _]      => handleArray(ar)
+    case st: StanStringLiteral           => handleString(st)
+    case lt: StanLiteral                 => handleLiteral(lt)
+    case un: StanUnknown[T]              => handleUnknown(un)
   }
 
   def handleCall[T <: StanType](call: StanCall[T]): State[StanValue[T]] = {
@@ -275,8 +275,7 @@ abstract class StanTransform[STATE](implicit ss: ScalaStan) {
 
   def handleLiteral[T <: StanType](l: StanLiteral): State[StanValue[T]] = State.pure(l.asInstanceOf[StanValue[T]])
 
-  def handleUnknownDim[T <: StanType](ud: StanUnknownDim): State[StanValue[T]] =
-    State.pure(ud.asInstanceOf[StanValue[T]])
+  def handleUnknown[T <: StanType](un: StanUnknown[T]): State[StanValue[T]] = State.pure(un.asInstanceOf[StanValue[T]])
 
   def handleVariable[T <: StanType](decl: StanDeclaration[T]): State[StanValue[T]] = State.pure(decl)
 

--- a/src/test/scala/com/cibo/scalastan/TransformedParameterSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/TransformedParameterSpec.scala
@@ -1,69 +1,66 @@
 package com.cibo.scalastan
 
-class TransformedParameterSpec extends ScalaStanBaseSpec {
+class TransformedParameterSpec extends ScalaStanBaseSpec with ScalaStan {
   describe("ParameterTransform") {
     it("should allow assignment to the result") {
-      new ScalaStan {
-        val t = new TransformedParameter(real()) {
-          result := 1
-        }
-        val model = new Model { local(real()) := t; }
-        checkCode(model, "transformed parameters { real t; { t = 1; } }")
+      val t = new TransformedParameter(real()) {
+        result := 1
       }
+      val model = new Model { local(real()) := t; }
+      checkCode(model, "transformed parameters { real t; { t = 1; } }")
     }
 
     it("should allow updating the result") {
-      new ScalaStan {
-        val t = new TransformedParameter(real()) {
-          result += 1
-        }
-        val model = new Model { local(real()) := t; }
-        checkCode(model, "transformed parameters { real t; { t += 1; } }")
+      val t = new TransformedParameter(real()) {
+        result += 1
       }
+      val model = new Model { local(real()) := t; }
+      checkCode(model, "transformed parameters { real t; { t += 1; } }")
     }
 
     it("should allow updating the result by index") {
-      new ScalaStan {
-        val t = new TransformedParameter(vector(2)) {
-          result(1) := 2.0
-        }
-        val model = new Model { local(vector(2)) := t; }
-        checkCode(model, "transformed parameters { vector[2] t; { t[1] = 2.0; } }")
+      val t = new TransformedParameter(vector(2)) {
+        result(1) := 2.0
       }
+      val model = new Model { local(vector(2)) := t; }
+      checkCode(model, "transformed parameters { vector[2] t; { t[1] = 2.0; } }")
     }
 
     it("should allow updating the result by slice") {
-      new ScalaStan {
-        val t = new TransformedParameter(vector(5)) {
-          result(range(1, 2)) := result(range(3, 4))
-        }
-        val model = new Model { local(vector(5)) := t; }
-        checkCode(model, "transformed parameters { vector[5] t; { t[1:2] = t[3:4]; } }")
+      val t = new TransformedParameter(vector(5)) {
+        result(range(1, 2)) := result(range(3, 4))
       }
+      val model = new Model {local(vector(5)) := t;}
+      checkCode(model, "transformed parameters { vector[5] t; { t[1:2] = t[3:4]; } }")
     }
 
     it("should output dependencies in the right order") {
-      new ScalaStan {
-        val a = new TransformedParameter(real()) {
-          result := 5
-        }
-        val b = new TransformedParameter(real()) {
-          result := a
-        }
-        val model = new Model { local(real()) := a; local(real()) := b }
-        checkCode(model, "transformed parameters { real a; real b; { a = 5; } { b = a; } }")
+      val a = new TransformedParameter(real()) {
+        result := 5
       }
+      val b = new TransformedParameter(real()) {
+        result := a
+      }
+      val model = new Model {local(real()) := a; local(real()) := b}
+      checkCode(model, "transformed parameters { real a; real b; { a = 5; } { b = a; } }")
     }
 
     it("should not allow assignment to data") {
       """
-      new ScalaStan {
-        val d = data(real())
-        new ParameterTransform(real()) {
-          d := 1
-        }
+      val d = data(real())
+      new TransformedParameter(real()) {
+        d := 1
       }
       """ shouldNot compile
+    }
+
+    it("should support non-trivial bounds") {
+      val d = data(real())
+      val pt = new TransformedParameter(real(lower = 1 / d)) {
+        result := 0.1
+      }
+      val model = new Model { local(real()) := pt }
+      checkCode(model, "transformed parameters { real<lower=(1) / (d)> pt; { pt = 0.1; } }")
     }
   }
 }


### PR DESCRIPTION
The upper/lower bounds on declarations used to be implemented as `Option[StanValue[T]]` with an implicit conversion to wrap bare values with the option.  Unfortunately, this doesn't work when the expression starts with an integer, for example, since that requires an addition implicit conversion.  So the end-user would have to manually wrap the value in an Option, which isn't exactly obvious from the error message.  Instead, this PR makes it so we use a special "unknown" value as the default.  This also removes the now unused implicit conversion since it can cause surprising things to happen.