### PR TITLE
Generic methods to access parameters

### DIFF
--- a/src/main/scala/com/cibo/scalastan/CodeBuilder.scala
+++ b/src/main/scala/com/cibo/scalastan/CodeBuilder.scala
@@ -21,8 +21,8 @@ protected class CodeBuilder {
   // Entering a new scope extends the number of buffers.
   private val stack = new ArrayBuffer[ArrayBuffer[StanStatement]]()
 
-  private val dataValues = ArrayBuffer[StanDataDeclaration[_]]()
-  private val parameterValues = ArrayBuffer[StanParameterDeclaration[_]]()
+  private val dataValues = ArrayBuffer[StanDataDeclaration[_ <: StanType]]()
+  private val parameterValues = ArrayBuffer[StanParameterDeclaration[_ <: StanType]]()
   private val functions = ArrayBuffer[ScalaStan#Function[_]]()
   private val transformedData = ArrayBuffer[ScalaStan#TransformedData[_]]()
   private val transformedParameters = ArrayBuffer[ScalaStan#TransformedParameter[_]]()
@@ -72,13 +72,13 @@ protected class CodeBuilder {
     other.generatedQuantities.foreach(append)
   }
 
-  def append(d: StanDataDeclaration[_]): Unit = {
+  def append(d: StanDataDeclaration[_ <: StanType]): Unit = {
     if (!dataValues.exists(_.id == d.id)) {
       dataValues += d
     }
   }
 
-  def append(d: StanParameterDeclaration[_]): Unit = {
+  def append(d: StanParameterDeclaration[_ <: StanType]): Unit = {
     if (!parameterValues.exists(_.id == d.id)) {
       parameterValues += d
     }

--- a/src/main/scala/com/cibo/scalastan/StanResults.scala
+++ b/src/main/scala/com/cibo/scalastan/StanResults.scala
@@ -46,6 +46,45 @@ case class StanResults private (
   val iterationsPerChain: Int = parameterChains.head._2.head.size
   val iterationsTotal: Int = chainCount * iterationsPerChain
 
+  /** Get all parameter declarations. */
+  def parameters: Seq[StanParameterDeclaration[_ <: StanType]] = model.model.program.parameters
+
+  /** Get all transformed parameters. */
+  def transformedParameters: Seq[StanParameterDeclaration[_ <: StanType]] =
+    model.model.program.transformedParameters.map(_.result)
+
+  /** Get all generated quantities. */
+  def generatedQuantities: Seq[StanParameterDeclaration[_ <: StanType]] =
+    model.model.program.generatedQuantities.map(_.result)
+
+  /** Get all data declarations. */
+  def data: Seq[StanDataDeclaration[_ <: StanType]] = model.model.program.data
+
+  private def declName(decl: StanParameterDeclaration[_ <: StanType]): String = {
+    decl.root.emit + (if (decl.indices.nonEmpty) decl.indices.mkString(".", ".", "") else "")
+  }
+
+  private def elementsHelper(
+    decl: StanParameterDeclaration[_ <: StanType],
+    value: Any,
+    indices: Vector[Int] = Vector.empty
+  ): Seq[StanParameterDeclaration[_ <: StanType]] = {
+    value match {
+      case vs: Seq[_] => vs.zipWithIndex.flatMap(v => elementsHelper(decl, v._1, indices :+ (v._2 + 1)))
+      case x          =>
+        val newName = if (indices.nonEmpty) indices.mkString(s"${decl.name}[", ",", "]") else decl.name
+        val newReturnType: StanType = indices.foldLeft(decl.returnType: StanType) { (t, _) => t.next }
+        Seq(StanParameterDeclaration(newReturnType, newName, decl.rootOpt.orElse(Some(decl)), decl.indices ++ indices))
+    }
+  }
+
+  /** Get scalar elements for a parameter declaration. */
+  def elements(decl: StanParameterDeclaration[_ <: StanType]): Seq[StanParameterDeclaration[_ <: StanType]] = {
+    val name = declName(decl)
+    val parsed = decl.returnType.parse(name, parameterChains).head.head
+    elementsHelper(decl, parsed)
+  }
+
   /** Get the specified input data. */
   def get[T <: StanType, R](
     decl: StanDataDeclaration[T]
@@ -55,7 +94,7 @@ case class StanResults private (
   def samples[T <: StanType, R](
     decl: StanParameterDeclaration[T]
   )(implicit ev: R =:= T#SCALA_TYPE): Seq[Seq[R]] = {
-    val name = decl.root.emit + (if (decl.indices.nonEmpty) decl.indices.mkString(".", ".", "") else "")
+    val name = declName(decl)
     decl.returnType.parse(name, parameterChains).asInstanceOf[Seq[Seq[R]]]
   }
 
@@ -294,11 +333,7 @@ case class StanResults private (
     val fieldWidth = 8
 
     // Get a mapping from Stan name to ScalaStan name.
-    val parametersToShow = if (parameters.nonEmpty) {
-      parameters
-    } else {
-      model.model.program.parameters ++ model.model.program.transformedParameters.map(_.result)
-    }
+    val parametersToShow = if (parameters.nonEmpty) parameters else this.parameters ++ this.transformedParameters
     val mapping = parametersToShow.map(p => p.emit -> p.name).toMap
 
     // Build a mapping of name -> chain -> iteration -> value

--- a/src/main/scala/com/cibo/scalastan/ast/StanDeclaration.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanDeclaration.scala
@@ -12,7 +12,7 @@ package com.cibo.scalastan.ast
 
 import com.cibo.scalastan._
 
-sealed abstract class StanDeclaration[T <: StanType](implicit ss: ScalaStan) extends StanValue[T] {
+sealed abstract class StanDeclaration[T <: StanType] extends StanValue[T] {
   val returnType: T
   val name: String
 
@@ -22,7 +22,7 @@ sealed abstract class StanDeclaration[T <: StanType](implicit ss: ScalaStan) ext
 
   def size(implicit ev: T <:< StanCompoundType): StanValue[StanInt] = dims.head
 
-  def range(implicit ev: T <:< StanCompoundType): StanValueRange = StanValueRange(1, size)
+  def range(implicit ev: T <:< StanCompoundType, ss: ScalaStan): StanValueRange = StanValueRange(1, size)
 
   def dims: Seq[StanValue[StanInt]] = returnType.getIndices
 
@@ -33,7 +33,7 @@ case class StanDataDeclaration[T <: StanType](
   returnType: T,
   name: String,
   id: Int = StanNode.getNextId
-)(implicit ss: ScalaStan) extends StanDeclaration[T] {
+) extends StanDeclaration[T] {
   require(returnType.isDerivedFromData,
     "data declaration bounds must be derived from other data declarations or constant")
   type DECL_TYPE = StanDataDeclaration[T]
@@ -55,7 +55,7 @@ case class StanParameterDeclaration[T <: StanType](
   indices: Seq[Int] = Seq.empty,
   owner: Option[ScalaStan#TransformBase[_, _]] = None,
   id: Int = StanNode.getNextId
-)(implicit ss: ScalaStan) extends StanDeclaration[T] with Updatable[T] {
+) extends StanDeclaration[T] with Updatable[T] {
   require(returnType.isDerivedFromData,
     "parameter declaration bounds must be derived from data declarations or constant")
   val value: StanDeclaration[_ <: StanType] = this
@@ -115,7 +115,7 @@ case class StanLocalDeclaration[T <: StanType] private[scalastan] (
   derivedFromData: Boolean = false,
   owner: Option[ScalaStan#TransformBase[_, _]] = None,
   id: Int = StanNode.getNextId
-)(implicit ss: ScalaStan) extends StanDeclaration[T] with Updatable[T] {
+) extends StanDeclaration[T] with Updatable[T] {
   val value: StanValue[_ <: StanType] = this
   type DECL_TYPE = StanLocalDeclaration[T]
   def isDerivedFromData: Boolean = derivedFromData

--- a/src/main/scala/com/cibo/scalastan/ast/StanProgram.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanProgram.scala
@@ -12,11 +12,12 @@ package com.cibo.scalastan.ast
 
 import java.io.PrintWriter
 
+import com.cibo.scalastan.StanType
 import com.cibo.scalastan.transform.StanTransform
 
 case class StanProgram(
-  data: Seq[StanDataDeclaration[_]] = Seq.empty,
-  parameters: Seq[StanParameterDeclaration[_]] = Seq.empty,
+  data: Seq[StanDataDeclaration[_ <: StanType]] = Seq.empty,
+  parameters: Seq[StanParameterDeclaration[_ <: StanType]] = Seq.empty,
   functions: Seq[StanFunctionDeclaration] = Seq.empty,
   transformedData: Seq[StanTransformedData] = Seq.empty,
   transformedParameters: Seq[StanTransformedParameter] = Seq.empty,

--- a/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
@@ -51,6 +51,36 @@ class StanResultsSpec extends ScalaStanBaseSpec {
   )
   val results = StanResults(mappedData, model)
 
+  describe("parameters") {
+    it("returns all parameters") {
+      results.parameters.size shouldBe 3
+    }
+  }
+
+  describe("elements") {
+    it("returns all the elements of a parameter") {
+      results.elements(TestScalaStan.v3).size shouldBe 6
+    }
+
+    it("returns the right thing for an array") {
+      results.elements(TestScalaStan.v2).map(_.name) shouldBe Vector(
+        TestScalaStan.v2.get(1).name,
+        TestScalaStan.v2.get(2).name,
+        TestScalaStan.v2.get(3).name
+      )
+    }
+
+    it("returns the right value for a scalar") {
+      results.elements(TestScalaStan.v1).map(_.name) shouldBe Seq(TestScalaStan.v1.name)
+    }
+  }
+
+  describe("data") {
+    it("returns data") {
+      results.data.size shouldBe 1
+    }
+  }
+
   describe("samples") {
     it("returns all scalar samples") {
       results.samples(TestScalaStan.v1) shouldBe Seq(Seq(1, 0))


### PR DESCRIPTION
This adds `parameters`, `transformedParameters`, `data`, and `generatedQuantities` to the `StanResults` object to allow one to iterate over all the parameters/data programmatically.  It also adds an `elements` method to get the terminal element type for a parameter.  This allows one to do things like check the rHat for all parameters without explicitly listing them out, etc.