### PR TITLE
Fix a few type issues with matrices

### DIFF
--- a/src/main/scala/com/cibo/scalastan/ScalaStan.scala
+++ b/src/main/scala/com/cibo/scalastan/ScalaStan.scala
@@ -139,6 +139,11 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
     dim: StanValue[StanInt]
   ): StanMatrix = StanMatrix(dim, dim, constraint = MatrixConstraint.CholeskyFactorCov)
 
+  def choleskyFactorCov(
+    rows: StanValue[StanInt],
+    cols: StanValue[StanInt]
+  ): StanMatrix = StanMatrix(rows, cols, constraint = MatrixConstraint.CholeskyFactorCov)
+
   trait StanCode {
 
     implicit val _code: CodeBuilder = new CodeBuilder

--- a/src/main/scala/com/cibo/scalastan/StanType.scala
+++ b/src/main/scala/com/cibo/scalastan/StanType.scala
@@ -484,7 +484,7 @@ object MatrixConstraint {
   case object CorrMatrix extends MatrixConstraint("corr_matrix", 1)
   case object CholeskyFactorCorr extends MatrixConstraint("cholesky_factor_corr", 1)
   case object CovMatrix extends MatrixConstraint("cov_matrix", 1)
-  case object CholeskyFactorCov extends MatrixConstraint("cholesky_factor_cov", 1)
+  case object CholeskyFactorCov extends MatrixConstraint("cholesky_factor_cov", 2)
 }
 
 case class StanMatrix(

--- a/src/main/scala/com/cibo/scalastan/StanType.scala
+++ b/src/main/scala/com/cibo/scalastan/StanType.scala
@@ -496,7 +496,7 @@ case class StanMatrix(
 ) extends StanVectorOrMatrix {
   protected type THIS_TYPE = StanMatrix
   type ELEMENT_TYPE = StanReal
-  type NEXT_TYPE = StanVector
+  type NEXT_TYPE = StanRowVector
   type REAL_TYPE = StanMatrix
   type SCALA_TYPE = Seq[Seq[Double]]
   type SUMMARY_TYPE = Seq[Seq[Double]]
@@ -560,5 +560,5 @@ case class StanMatrix(
     }.toVector
   }
 
-  final def next: NEXT_TYPE = StanVector(cols, lower, upper)
+  final def next: NEXT_TYPE = StanRowVector(cols, lower, upper)
 }

--- a/src/main/scala/com/cibo/scalastan/TypeCheck.scala
+++ b/src/main/scala/com/cibo/scalastan/TypeCheck.scala
@@ -63,6 +63,9 @@ protected object MultiplicationAllowed {
   implicit val vecRvMultiplication = new MultiplicationAllowed[StanMatrix, StanVector, StanRowVector] {
     def newType(left: StanVector, right: StanRowVector): StanMatrix = StanMatrix(left.dim, right.dim)
   }
+  implicit val matMatMultiplication = new MultiplicationAllowed[StanMatrix, StanMatrix, StanMatrix] {
+    def newType(left: StanMatrix, right: StanMatrix): StanMatrix = StanMatrix(left.rows, right.cols)
+  }
 }
 
 @implicitNotFound("division not allowed for ${R} = ${A} * ${B}")

--- a/src/test/scala/com/cibo/scalastan/ast/StanValueSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/ast/StanValueSpec.scala
@@ -67,6 +67,22 @@ class StanValueSpec extends ScalaStanBaseSpec {
     }
   }
 
+  describe("*") {
+    it("can multiply doubles") {
+      val r = StanConstant[StanReal](StanReal(), 1) * 3.0
+      r.emit shouldBe "(1.0) * (3.0)"
+    }
+
+    it("can multiply matrices") {
+      val mat = StanLocalDeclaration(
+        StanMatrix(StanConstant[StanInt](StanInt(), 2), StanConstant[StanInt](StanInt(), 2)),
+        "mat"
+      )
+      val r = mat * mat
+      r.emit shouldBe "(mat) * (mat)"
+    }
+  }
+
   describe(":/") {
     it("can divide vectors") {
       val n = StanLocalDeclaration(StanInt(), "n")

--- a/src/test/scala/com/cibo/scalastan/ast/StanValueSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/ast/StanValueSpec.scala
@@ -172,6 +172,25 @@ class StanValueSpec extends ScalaStanBaseSpec {
       d.emit shouldBe "d[1,2]"
     }
 
+    it("can slice a matrix") {
+      val i1 = StanConstant[StanInt](StanInt(), 1)
+      val i2 = StanConstant[StanInt](StanInt(), 2)
+      val d = StanLocalDeclaration(StanMatrix(i1, i2), "d").apply(i1)
+      d.returnType shouldBe an[StanRowVector]
+      d.emit shouldBe "d[1]"
+    }
+
+    it("can assign to a slice of a matrix") {
+      new ScalaStan {
+        val model = new Model {
+          val d = local(matrix(1, 2))
+          val rv = local(rowVector(2))
+          d(1) := rv
+        }
+        checkCode(model, "d[1] = rv;")
+      }
+    }
+
     it("can set vector") {
       new ScalaStan {
         val model = new Model {


### PR DESCRIPTION
This fixes the following:
* Non-square cholesky_factor_cov matrices.
* Matrix-matrix multiply now type checks correctly.
* Indexing a matrix with a single dimension returns a row_vector (instead of a vector).
