### PR TITLE
Expose the `metrics_file` option

### DIFF
--- a/src/main/scala/com/cibo/scalastan/RunMethod.scala
+++ b/src/main/scala/com/cibo/scalastan/RunMethod.scala
@@ -139,12 +139,14 @@ object RunMethod {
   case class Hmc(
     engine: Engine = Nuts(),
     metric: Metric = DiagE,
+    metricFile: String = "",
     stepsize: Int = 1,
     stepsizeJitter: Int = 0
   ) extends SampleAlgorithm("hmc") {
     def arguments: Seq[String] = build(
       ("engine", engine, Hmc().engine),
       ("metric", metric, Hmc().metric),
+      ("metric_file", metricFile, Hmc().metricFile),
       ("stepsize", stepsize, Hmc().stepsize),
       ("stepsize_jitter", stepsizeJitter, Hmc().stepsizeJitter)
     )

--- a/src/main/scala/com/cibo/scalastan/ScalaStan.scala
+++ b/src/main/scala/com/cibo/scalastan/ScalaStan.scala
@@ -25,7 +25,7 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
   type ParameterDeclaration[T <: StanType] = StanParameterDeclaration[T]
   type DataDeclaration[T <: StanType] = StanDataDeclaration[T]
 
-  protected object stan extends StanFunctions with StanDistributions
+  object stan extends StanFunctions with StanDistributions
 
   // Maximum number of models to cache.
   val maxCacheSize: Int = 100

--- a/src/main/scala/com/cibo/scalastan/StanResults.scala
+++ b/src/main/scala/com/cibo/scalastan/StanResults.scala
@@ -17,8 +17,9 @@ import com.cibo.scalastan.ast.{StanDataDeclaration, StanParameterDeclaration}
 import scala.util.Try
 
 case class StanResults private (
-  private val parameterChains: Map[String, Vector[Vector[String]]],
-  private val model: CompiledModel
+  parameterChains: Map[String, Vector[Vector[String]]],
+  inverseMassMatrixDiagonals: Vector[Vector[Double]],
+  model: CompiledModel
 ) {
 
   require(parameterChains.nonEmpty, "No results")

--- a/src/test/scala/com/cibo/scalastan/ScalaStanBaseSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/ScalaStanBaseSpec.scala
@@ -36,7 +36,7 @@ trait ScalaStanBaseSpec extends FunSpec with Matchers {
         val iterations = grouped.map { case (k, v) => v }
         Vector.fill(chains)(iterations)
       }
-      StanResults(mappedData, model)
+      StanResults(mappedData, Vector.empty, model)
     }
   }
 

--- a/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
@@ -49,7 +49,7 @@ class StanResultsSpec extends ScalaStanBaseSpec {
   val mappedData: Map[String, Vector[Vector[String]]] = Seq(testData1, testData2).flatten.groupBy(_._1).mapValues(
     grouped => Vector(grouped.map{ case(k, v) => v }.toVector)
   )
-  val results = StanResults(mappedData, model)
+  val results = StanResults(mappedData, Vector.empty, model)
 
   describe("parameters") {
     it("returns all parameters") {


### PR DESCRIPTION
This exposes the `metrics_file` option, which can be used to provide the initial inverse mass matrix.  This also parses the comment from the output file containing the inverse mass matrix so that these could be passed back into a later run.