### PR TITLE
Transform and type check fixes

### DIFF
--- a/src/main/scala/com/cibo/scalastan/CodeBuilder.scala
+++ b/src/main/scala/com/cibo/scalastan/CodeBuilder.scala
@@ -40,11 +40,13 @@ protected class CodeBuilder {
   def leave(f: Seq[StanStatement] => StanStatement): Unit = {
     require(stack.size > 1)
     val result = f(stack.remove(stack.size - 1))
+    result.export(this)
     stack.last += result
   }
 
   // Special handling for "else if" statements.
   def handleElseIf(cond: StanValue[StanInt]): Unit = {
+    cond.export(this)
     val inside = stack.remove(stack.size - 1)
     val ifStatement = stack.last.remove(stack.last.size - 1).asInstanceOf[StanIfStatement]
     stack.last += ifStatement.copy(ifStatement.conds :+ (cond, StanBlock(inside)))

--- a/src/main/scala/com/cibo/scalastan/TypeCheck.scala
+++ b/src/main/scala/com/cibo/scalastan/TypeCheck.scala
@@ -497,4 +497,5 @@ protected object SampleAllowed {
   implicit def sameType[T <: StanType] = new SampleAllowed[T, T]
   implicit def vectorized[T <: StanVectorLike, SUPPORT <: StanScalarType] = new SampleAllowed[T, SUPPORT]
   implicit def arrayVectorized[T <: StanScalarType, SUPPORT <: StanScalarType] = new SampleAllowed[StanArray[T], SUPPORT]
+  implicit def vectorVectorized[T <: StanVectorLike, SUPPORT <: StanVectorLike] = new SampleAllowed[StanArray[T], SUPPORT]
 }

--- a/src/test/scala/com/cibo/scalastan/StanDistributionsSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/StanDistributionsSpec.scala
@@ -1,24 +1,20 @@
 package com.cibo.scalastan
 
-class StanDistributionsSpec extends ScalaStanBaseSpec {
+class StanDistributionsSpec extends ScalaStanBaseSpec with ScalaStan {
   describe("poisson") {
     it("should work with integers") {
-      new ScalaStan {
-        val x = data(int())
-        val model = new Model {
-          x ~ stan.poisson(1.0)
-        }
-        checkCode(model, "model { x ~ poisson(1.0); }")
+      val x = data(int())
+      val model = new Model {
+        x ~ stan.poisson(1.0)
       }
+      checkCode(model, "model { x ~ poisson(1.0); }")
     }
 
     it("should not work with reals") {
       """
-        new ScalaStan {
-          val x = data(real())
-          val model = new Model {
-            x ~ stan.poisson(1.0)
-          }
+        val x = data(real())
+        val model = new Model {
+          x ~ stan.poisson(1.0)
         }
       """ shouldNot compile
     }
@@ -26,27 +22,44 @@ class StanDistributionsSpec extends ScalaStanBaseSpec {
 
   describe("inv_wishart") {
     it("should work") {
-      new ScalaStan {
-        val nu = parameter(real())
-        val sigma = parameter(matrix(5, 5))
-        val y = data(matrix(5, 5))
-        val model = new Model {
-          y ~ stan.inv_wishart(nu, sigma)
-        }
-        checkCode(model, "model { y ~ inv_wishart(nu, sigma); }")
+      val nu = parameter(real())
+      val sigma = parameter(matrix(5, 5))
+      val y = data(matrix(5, 5))
+      val model = new Model {
+        y ~ stan.inv_wishart(nu, sigma)
       }
+      checkCode(model, "model { y ~ inv_wishart(nu, sigma); }")
     }
   }
 
   describe("lkj_corr_cholesky") {
     it("should work") {
-      new ScalaStan {
-        val y = data(matrix(5, 5))
-        val model = new Model {
-          y ~ stan.lkj_corr_cholesky(5, 2)
-        }
-        checkCode(model, "model { y ~ lkj_corr_cholesky(2); }")
+      val y = data(matrix(5, 5))
+      val model = new Model {
+        y ~ stan.lkj_corr_cholesky(5, 2)
       }
+      checkCode(model, "model { y ~ lkj_corr_cholesky(2); }")
+    }
+  }
+
+  describe("multi_normal") {
+    it("should vectorize") {
+      val k = data(int())
+      val j = data(int())
+      val n = data(int())
+      val x = data(vector(n)(j))
+      val y = data(vector(n)(k))
+      val beta = parameter(matrix(k, j))
+      val sigma = parameter(covMatrix(k))
+      val model = new Model {
+        val mu = local(vector(k)(n))
+        for (n <- range(1, n)) {
+          mu(n) := beta * x(n)
+          beta * x(n)
+        }
+        y ~ stan.multi_normal(mu, sigma)
+      }
+      checkCode(model, "y ~ multi_normal(mu, sigma);")
     }
   }
 }

--- a/src/test/scala/com/cibo/scalastan/TransformedParameterSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/TransformedParameterSpec.scala
@@ -62,5 +62,16 @@ class TransformedParameterSpec extends ScalaStanBaseSpec with ScalaStan {
       val model = new Model { local(real()) := pt }
       checkCode(model, "transformed parameters { real<lower=(1) / (d)> pt; { pt = 0.1; } }")
     }
+
+    it("should preserve transformed parameters used in conditionals") {
+      val tp = new TransformedParameter(real()) {
+        result := 1.0
+      }
+      val model = new Model {
+        when(tp > 0) {
+        }
+      }
+      checkCode(model, "transformed parameters { real tp; { tp = 1.0; } }")
+    }
   }
 }


### PR DESCRIPTION
This fixes a couple issues:
* Transforms only referenced in a conditional are now exported correctly.
* Type checking for vectorization of vector valued distributions is fixed.

See the associated tests for examples.