### PR TITLE
Ternary operator

### DIFF
--- a/src/it/scala/com/cibo/scalastan/examples/BernoulliExample.scala
+++ b/src/it/scala/com/cibo/scalastan/examples/BernoulliExample.scala
@@ -20,9 +20,9 @@ object BernoulliExample extends App with ScalaStan {
   println(s"mean(${theta.name}) = ${results.mean(theta)}")
   println(s"N_Eff(${theta.name}) = ${results.effectiveSampleSize(theta)}")
 
-  results.checkTreeDepth()
-  results.checkEnergy()
-  results.checkDivergence()
+  println(s"Iterations saturation the max tree depth: ${results.checkTreeDepth}")
+  println(s"Iterations below the energy threshold: ${results.checkEnergy()}")
+  println(s"Iterations with a divergence: ${results.checkDivergence}")
 
   results.summary(System.out)
 }

--- a/src/it/scala/com/cibo/scalastan/examples/ElasticNetExample.scala
+++ b/src/it/scala/com/cibo/scalastan/examples/ElasticNetExample.scala
@@ -84,8 +84,8 @@ object ElasticNetExample extends App with ScalaStan {
   }
 
   // Ridge/lasso weights.
-  val lambda1 = data(real(lower = 0))
-  val lambda2 = data(real(lower = 0))
+  val lambda1 = data(real(lower = 0.0))
+  val lambda2 = data(real(lower = 0.0))
 
   // Inputs.
   val (n, p) = (data(int(lower = 0)), data(int(lower = 0)))

--- a/src/main/scala/com/cibo/scalastan/ScalaStan.scala
+++ b/src/main/scala/com/cibo/scalastan/ScalaStan.scala
@@ -143,7 +143,7 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
 
   trait StanCode {
 
-    implicit val _code: CodeBuilder = new CodeBuilder
+    implicit val _code: StanProgramBuilder = new StanProgramBuilder
 
     def local[T <: StanType](typeConstructor: T)(implicit name: sourcecode.Name): StanLocalDeclaration[T] = {
       if (typeConstructor.lower.isDefined || typeConstructor.upper.isDefined) {
@@ -211,7 +211,7 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
 
   abstract class TransformBase[T <: StanType, D <: StanDeclaration[T]] extends StanCode {
     private[scalastan] val result: D
-    private[scalastan] def export(builder: CodeBuilder): Unit
+    private[scalastan] def export(builder: StanProgramBuilder): Unit
     val name: String
   }
 
@@ -238,7 +238,7 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
       _code.append(StanReturnStatement(value))
     }
 
-    def apply(args: StanValue[_ <: StanType]*)(implicit code: CodeBuilder): StanCall[RETURN_TYPE] = {
+    def apply(args: StanValue[_ <: StanType]*)(implicit code: StanProgramBuilder): StanCall[RETURN_TYPE] = {
       val node = StanCall[RETURN_TYPE](returnType, this, args)
       if (returnType == StanVoid()) {
         code.append(StanValueStatement(node))
@@ -246,7 +246,7 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
       node
     }
 
-    private[scalastan] def export(builder: CodeBuilder): Unit = builder.append(this)
+    private[scalastan] def export(builder: StanProgramBuilder): Unit = builder.append(this)
 
     private[scalastan] lazy val generate: StanFunctionDeclaration = StanFunctionDeclaration(
       result,
@@ -267,7 +267,7 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
       typeConstructor, name, derivedFromData = true, owner = Some(this)
     )
 
-    private[scalastan] def export(builder: CodeBuilder): Unit = builder.append(this)
+    private[scalastan] def export(builder: StanProgramBuilder): Unit = builder.append(this)
 
     private[scalastan] lazy val generate: StanTransformedData = StanTransformedData(result, _code.results)
   }
@@ -284,7 +284,7 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
       StanParameterDeclaration[T](typeConstructor, name, owner = Some(this))
     protected implicit val _parameterTransform: InParameterTransform = InParameterTransform
 
-    private[scalastan] def export(builder: CodeBuilder): Unit = builder.append(this)
+    private[scalastan] def export(builder: StanProgramBuilder): Unit = builder.append(this)
 
     private[scalastan] lazy val generate: StanTransformedParameter = StanTransformedParameter(result, _code.results)
   }
@@ -314,7 +314,7 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
 
       protected implicit val _rngAvailable: RngAvailable = RngAvailable
 
-      private[scalastan] def export(builder: CodeBuilder): Unit = builder.append(this)
+      private[scalastan] def export(builder: StanProgramBuilder): Unit = builder.append(this)
 
       private[scalastan] lazy val generate: StanGeneratedQuantity = StanGeneratedQuantity(result, _code.results)
     }

--- a/src/main/scala/com/cibo/scalastan/ScalaStan.scala
+++ b/src/main/scala/com/cibo/scalastan/ScalaStan.scala
@@ -174,6 +174,10 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
       }
     }
 
+    def when[T <: StanType](cond: StanValue[StanInt], ifTrue: StanValue[T], ifFalse: StanValue[T]): StanValue[T] = {
+      StanTernaryOperator(cond, ifTrue, ifFalse)
+    }
+
     def range(start: StanValue[StanInt], end: StanValue[StanInt]): StanValueRange = StanValueRange(start, end)
 
     def loop(cond: StanValue[StanInt])(body: => Unit): Unit = {

--- a/src/main/scala/com/cibo/scalastan/StanFunctions.scala
+++ b/src/main/scala/com/cibo/scalastan/StanFunctions.scala
@@ -17,8 +17,8 @@ import scala.collection.mutable.ArrayBuffer
 protected trait StanFunctions {
 
   // Reject (5.10).
-  def reject(args: StanValue[_ <: StanType]*)(implicit code: StanProgramBuilder): Unit = {
-    code.append(StanValueStatement(StanCall(StanVoid(), "reject", args)))
+  def reject(arg: StanValue[_ <: StanType], args: StanValue[_ <: StanType]*)(implicit code: StanProgramBuilder): Unit = {
+    code.append(StanValueStatement(StanCall(StanVoid(), "reject", arg +: args)))
   }
 
   // Print (38.1).

--- a/src/main/scala/com/cibo/scalastan/StanFunctions.scala
+++ b/src/main/scala/com/cibo/scalastan/StanFunctions.scala
@@ -17,12 +17,12 @@ import scala.collection.mutable.ArrayBuffer
 protected trait StanFunctions {
 
   // Reject (5.10).
-  def reject(args: StanValue[_ <: StanType]*)(implicit code: CodeBuilder): Unit = {
+  def reject(args: StanValue[_ <: StanType]*)(implicit code: StanProgramBuilder): Unit = {
     code.append(StanValueStatement(StanCall(StanVoid(), "reject", args)))
   }
 
   // Print (38.1).
-  def print(args: StanValue[_ <: StanType]*)(implicit code: CodeBuilder): Unit = {
+  def print(args: StanValue[_ <: StanType]*)(implicit code: StanProgramBuilder): Unit = {
     code.append(StanValueStatement(StanCall(StanVoid(), "print", args)))
   }
 
@@ -508,7 +508,7 @@ protected trait StanFunctions {
     theta: StanValue[StanArray[StanReal]],
     xr: StanValue[StanArray[StanReal]],
     xi: StanValue[StanArray[StanInt]]
-  )(implicit code: CodeBuilder): StanValue[StanArray[StanArray[StanReal]]] = {
+  )(implicit code: StanProgramBuilder): StanValue[StanArray[StanArray[StanReal]]] = {
     ode.export(code)
     StanCall(
       StanArray(initialState.returnType.dim, StanArray(times.returnType.dim, StanReal())),
@@ -527,7 +527,7 @@ protected trait StanFunctions {
     relTol: StanValue[RT],
     absTol: StanValue[AT],
     maxNumSteps: StanValue[StanInt]
-  )(implicit code: CodeBuilder): StanValue[StanArray[StanArray[StanReal]]] = {
+  )(implicit code: StanProgramBuilder): StanValue[StanArray[StanArray[StanReal]]] = {
     ode.export(code)
     StanCall(
       StanArray(initialState.returnType.dim, StanArray(times.returnType.dim, StanReal())),
@@ -555,7 +555,7 @@ protected trait StanFunctions {
     theta: StanValue[StanArray[StanReal]],
     xr: StanValue[StanArray[StanReal]],
     xi: StanValue[StanArray[StanInt]]
-  )(implicit code: CodeBuilder): StanValue[StanArray[StanArray[StanReal]]] = {
+  )(implicit code: StanProgramBuilder): StanValue[StanArray[StanArray[StanReal]]] = {
     ode.export(code)
     StanCall(
       StanArray(initialState.returnType.dim, StanArray(times.returnType.dim, StanReal())),
@@ -574,7 +574,7 @@ protected trait StanFunctions {
     relTol: StanValue[RT],
     absTol: StanValue[AT],
     maxNumSteps: StanValue[StanInt]
-  )(implicit code: CodeBuilder): StanValue[StanArray[StanArray[StanReal]]] = {
+  )(implicit code: StanProgramBuilder): StanValue[StanArray[StanArray[StanReal]]] = {
     ode.export(code)
     StanCall(
       StanArray(initialState.returnType.dim, StanArray(times.returnType.dim, StanReal())),

--- a/src/main/scala/com/cibo/scalastan/StanProgramBuilder.scala
+++ b/src/main/scala/com/cibo/scalastan/StanProgramBuilder.scala
@@ -14,7 +14,7 @@ import com.cibo.scalastan.ast._
 
 import scala.collection.mutable.ArrayBuffer
 
-protected class CodeBuilder {
+class StanProgramBuilder {
 
   // Stack of statements.
   // New statements are appended to the last buffer.
@@ -65,7 +65,7 @@ protected class CodeBuilder {
     stack.last.insert(0, s)
   }
 
-  def append(other: CodeBuilder): Unit = {
+  def append(other: StanProgramBuilder): Unit = {
     other.dataValues.foreach(append)
     other.parameterValues.foreach(append)
     other.functions.foreach(append)

--- a/src/main/scala/com/cibo/scalastan/StanResults.scala
+++ b/src/main/scala/com/cibo/scalastan/StanResults.scala
@@ -293,13 +293,10 @@ case class StanResults private (
     count > 0
   }
 
-  def checkEnergy(threshold: Double = 0.2): Boolean = {
-    val count = energy.map(_.count(_ < threshold)).sum
-    val p = (100 * count) / iterationsTotal
-    println(s"$count of $iterationsTotal iterations exceeded the energy threshold of $threshold ($p%)")
-    count > 0
-  }
+  /** Get the number of iterations below the specified energy threshold. */
+  def checkEnergy(threshold: Double = 0.2): Int = energy.map(_.count(_ < threshold)).sum
 
+  /** Get the total number of divergences after warmup. */
   def checkDivergence: Int = divergent.map(_.count(_ > 0.0)).sum
 
   /** Partition iterations into (divergent, non-divergent) samples. */

--- a/src/main/scala/com/cibo/scalastan/ast/StanDeclaration.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanDeclaration.scala
@@ -38,7 +38,7 @@ case class StanDataDeclaration[T <: StanType](
     "data declaration bounds must be derived from other data declarations or constant")
   type DECL_TYPE = StanDataDeclaration[T]
   def isDerivedFromData: Boolean = true
-  def export(builder: CodeBuilder): Unit = {
+  def export(builder: StanProgramBuilder): Unit = {
     returnType.lower.foreach(_.export(builder))
     returnType.upper.foreach(_.export(builder))
     returnType.getIndices.foreach(_.export(builder))
@@ -61,7 +61,7 @@ case class StanParameterDeclaration[T <: StanType](
   val value: StanDeclaration[_ <: StanType] = this
   type DECL_TYPE = StanParameterDeclaration[T]
   def isDerivedFromData: Boolean = false
-  def export(builder: CodeBuilder): Unit = {
+  def export(builder: StanProgramBuilder): Unit = {
     indices.foreach(_.export(builder))
     returnType.lower.foreach(_.export(builder))
     returnType.upper.foreach(_.export(builder))
@@ -119,7 +119,7 @@ case class StanLocalDeclaration[T <: StanType] private[scalastan] (
   val value: StanValue[_ <: StanType] = this
   type DECL_TYPE = StanLocalDeclaration[T]
   def isDerivedFromData: Boolean = derivedFromData
-  def export(builder: CodeBuilder): Unit = {
+  def export(builder: StanProgramBuilder): Unit = {
     returnType.lower.foreach(_.export(builder))
     returnType.upper.foreach(_.export(builder))
     returnType.getIndices.foreach(_.export(builder))

--- a/src/main/scala/com/cibo/scalastan/ast/StanDistribution.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanDistribution.scala
@@ -25,7 +25,7 @@ sealed abstract class StanDistribution[T <: StanType, R <: StanType] extends Sta
     args.flatMap(_.outputs) ++ lowerOpt.toSeq.flatMap(_.outputs) ++ upperOpt.toSeq.flatMap(_.outputs)
   def values: Seq[StanValue[_ <: StanType]] = args ++ lowerOpt.toSeq ++ upperOpt.toSeq
 
-  private[scalastan] def export(builder: CodeBuilder): Unit = {
+  private[scalastan] def export(builder: StanProgramBuilder): Unit = {
     args.foreach(_.export(builder))
     lowerOpt.foreach(_.export(builder))
     upperOpt.foreach(_.export(builder))

--- a/src/main/scala/com/cibo/scalastan/ast/StanNode.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanNode.scala
@@ -42,13 +42,13 @@ case class StanValueRange(
   private[scalastan] def inputs: Seq[StanDeclaration[_ <: StanType]] = start.inputs ++ end.inputs
   private[scalastan] def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
 
-  private[scalastan] def export(builder: CodeBuilder): Unit = {
+  private[scalastan] def export(builder: StanProgramBuilder): Unit = {
     start.export(builder)
     end.export(builder)
   }
 
   // This foreach will get called automatically when a for comprehension is used with ValueRange.
-  def foreach(f: StanValue[StanInt] => Unit)(implicit ev: TemporaryValue[StanInt], builder: CodeBuilder): Unit = {
+  def foreach(f: StanValue[StanInt] => Unit)(implicit ev: TemporaryValue[StanInt], builder: StanProgramBuilder): Unit = {
     val temp = ev.create()
     val decl = StanLocalDeclaration[StanInt](temp, ss.newName)
     builder.enter()

--- a/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
@@ -392,6 +392,25 @@ case class StanTranspose[T <: StanType, R <: StanType](
   def emit: String = s"${value.emit}'"
 }
 
+case class StanTernaryOperator[C <: StanType, T <: StanType](
+  cond: StanValue[C],
+  left: StanValue[T],
+  right: StanValue[T],
+  id: Int = StanNode.getNextId
+) extends StanValue[T] {
+  val returnType: T = left.returnType
+  def inputs: Seq[StanDeclaration[_ <: StanType]] = cond.inputs ++ left.inputs ++ right.inputs
+  def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
+  def children: Seq[StanValue[_ <: StanType]] = Seq[StanValue[_ <: StanType]](cond, left, right)
+  def isDerivedFromData: Boolean = cond.isDerivedFromData && left.isDerivedFromData && right.isDerivedFromData
+  def export(builder: StanProgramBuilder): Unit = {
+    cond.export(builder)
+    left.export(builder)
+    right.export(builder)
+  }
+  def emit: String = s"(${cond.emit} ? ${left.emit} : ${right.emit})"
+}
+
 case class StanConstant[T <: StanType](
   returnType: T,
   value: T#SCALA_TYPE,

--- a/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
@@ -27,7 +27,7 @@ abstract class StanValue[T <: StanType] extends StanNode with Implicits {
   def outputs: Seq[StanDeclaration[_ <: StanType]]
   def children: Seq[StanValue[_ <: StanType]]
 
-  def export(builder: CodeBuilder): Unit
+  def export(builder: StanProgramBuilder): Unit
 
   // Check if this value is derived from data only.
   def isDerivedFromData: Boolean
@@ -107,7 +107,7 @@ abstract class StanValue[T <: StanType] extends StanNode with Implicits {
     StanBinaryOperator(StanBinaryOperator.ElementWiseDivide, ev.newType(returnType, right.returnType), this, right)
 
   def ~[R <: StanType](dist: StanDistribution[T, R])(
-    implicit code: CodeBuilder,
+    implicit code: StanProgramBuilder,
     ev: SampleAllowed[T, R]
   ): Unit = {
     code.append(StanSampleStatement[T, R](this, dist))
@@ -116,7 +116,7 @@ abstract class StanValue[T <: StanType] extends StanNode with Implicits {
   def t[R <: StanType](implicit e: TransposeAllowed[T, R]): StanValue[R] = StanTranspose(e.newType(returnType), this)
 
   def :=[R <: StanType](right: StanValue[R])(
-    implicit code: CodeBuilder,
+    implicit code: StanProgramBuilder,
     ev1: AssignmentAllowed[DECL_TYPE],
     ev2: CanConvert[R, T]
   ): StanAssignment = {
@@ -165,7 +165,7 @@ abstract class StanValue[T <: StanType] extends StanNode with Implicits {
 trait Incrementable[T <: StanType] { self: StanValue[T] =>
   def +=[B <: StanType](right: StanValue[B])(
     implicit ev: AdditionAllowed[T, T, B],
-    code: CodeBuilder
+    code: StanProgramBuilder
   ): Unit = {
     code.append(StanAssignment(this, right, StanAssignment.Add))
   }
@@ -173,19 +173,19 @@ trait Incrementable[T <: StanType] { self: StanValue[T] =>
 
 trait Updatable[T <: StanType] extends Incrementable[T] { self: StanValue[T] =>
   def -=[B <: StanType](right: StanValue[B])(
-    implicit ev: AdditionAllowed[T, T, B], code: CodeBuilder
+    implicit ev: AdditionAllowed[T, T, B], code: StanProgramBuilder
   ): Unit = {
     code.append(StanAssignment(this, right, StanAssignment.Subtract))
   }
 
   def *=[B <: StanType](right: StanValue[B])(
-    implicit ev: MultiplicationAllowed[T, T, B], code: CodeBuilder
+    implicit ev: MultiplicationAllowed[T, T, B], code: StanProgramBuilder
   ): Unit = {
     code.append(StanAssignment(this, right, StanAssignment.Multiply))
   }
 
   def /=[B <: StanScalarType](right: StanValue[B])(
-    implicit code: CodeBuilder
+    implicit code: StanProgramBuilder
   ): Unit = {
     code.append(StanAssignment(this, right, StanAssignment.Divide))
   }
@@ -193,11 +193,11 @@ trait Updatable[T <: StanType] extends Incrementable[T] { self: StanValue[T] =>
 
 trait StanFunction {
   def name: String
-  private[scalastan] def export(builder: CodeBuilder): Unit
+  private[scalastan] def export(builder: StanProgramBuilder): Unit
 }
 
 case class BuiltinFunction(name: String) extends StanFunction {
-  private[scalastan] def export(bulder: CodeBuilder): Unit = ()
+  private[scalastan] def export(bulder: StanProgramBuilder): Unit = ()
 }
 
 case class StanCall[T <: StanType](
@@ -210,7 +210,7 @@ case class StanCall[T <: StanType](
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = args
   def isDerivedFromData: Boolean = args.forall(_.isDerivedFromData)
-  def export(builder: CodeBuilder): Unit = {
+  def export(builder: StanProgramBuilder): Unit = {
     args.foreach(_.export(builder))
     function.export(builder)
   }
@@ -242,7 +242,7 @@ case class StanGetTarget(
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = Seq.empty
   def isDerivedFromData: Boolean = false
-  def export(builder: CodeBuilder): Unit = ()
+  def export(builder: StanProgramBuilder): Unit = ()
   def emit: String = "target()"
 }
 
@@ -254,7 +254,7 @@ case class StanTargetValue(
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = Seq.empty
   def isDerivedFromData: Boolean = false
-  def export(builder: CodeBuilder): Unit = ()
+  def export(builder: StanProgramBuilder): Unit = ()
   def emit: String = "target"
   def apply(): StanGetTarget = StanGetTarget()
 }
@@ -271,7 +271,7 @@ case class StanDistributionNode[T <: StanType](
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = y +: args
   def isDerivedFromData: Boolean = false
-  def export(builder: CodeBuilder): Unit = {
+  def export(builder: StanProgramBuilder): Unit = {
     args.foreach(_.export(builder))
     y.export(builder)
   }
@@ -291,7 +291,7 @@ case class StanUnaryOperator[T <: StanType, R <: StanType](
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = Seq(right)
   def isDerivedFromData: Boolean = right.isDerivedFromData
-  def export(builder: CodeBuilder): Unit = right.export(builder)
+  def export(builder: StanProgramBuilder): Unit = right.export(builder)
   def emit: String = s"${op.name}(${right.emit})"
 }
 
@@ -313,7 +313,7 @@ case class StanBinaryOperator[T <: StanType, L <: StanType, R <: StanType](
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = Seq[StanValue[_ <: StanType]](left, right)
   def isDerivedFromData: Boolean = left.isDerivedFromData && right.isDerivedFromData
-  def export(builder: CodeBuilder): Unit = {
+  def export(builder: StanProgramBuilder): Unit = {
     left.export(builder)
     right.export(builder)
   }
@@ -357,7 +357,7 @@ case class StanIndexOperator[T <: StanType, N <: StanType, D <: StanDeclaration[
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = value +: indices
   def isDerivedFromData: Boolean = value.isDerivedFromData && indices.forall(_.isDerivedFromData)
-  def export(builder: CodeBuilder): Unit = {
+  def export(builder: StanProgramBuilder): Unit = {
     value.export(builder)
     indices.foreach(_.export(builder))
   }
@@ -376,7 +376,7 @@ case class StanSliceOperator[T <: StanType, D <: StanDeclaration[_]](
   def children: Seq[StanValue[_ <: StanType]] = Seq[StanValue[_ <: StanType]](value, slice.start, slice.end)
   def isDerivedFromData: Boolean =
     value.isDerivedFromData && slice.start.isDerivedFromData && slice.end.isDerivedFromData
-  def export(builder: CodeBuilder): Unit = {
+  def export(builder: StanProgramBuilder): Unit = {
     value.export(builder)
     slice.export(builder)
   }
@@ -392,7 +392,7 @@ case class StanTranspose[T <: StanType, R <: StanType](
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = Seq(value)
   def isDerivedFromData: Boolean = value.isDerivedFromData
-  def export(builder: CodeBuilder): Unit = {
+  def export(builder: StanProgramBuilder): Unit = {
     value.export(builder)
   }
   def emit: String = s"(${value.emit})'"
@@ -407,7 +407,7 @@ case class StanConstant[T <: StanType](
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = Seq.empty
   def isDerivedFromData: Boolean = true
-  def export(builder: CodeBuilder): Unit = ()
+  def export(builder: StanProgramBuilder): Unit = ()
   def emit: String = value.toString
 }
 
@@ -420,7 +420,7 @@ case class StanArrayLiteral[N <: StanType, T <: StanArray[N]](
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = values
   def isDerivedFromData: Boolean = true
-  def export(builder: CodeBuilder): Unit = {
+  def export(builder: StanProgramBuilder): Unit = {
     values.foreach(_.export(builder))
   }
   def emit: String = values.map(_.emit).mkString("{", ",", "}")
@@ -435,7 +435,7 @@ case class StanStringLiteral(
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = Seq.empty
   def isDerivedFromData: Boolean = true
-  def export(builder: CodeBuilder): Unit = ()
+  def export(builder: StanProgramBuilder): Unit = ()
   def emit: String = s""""$value""""
 }
 
@@ -448,7 +448,7 @@ case class StanLiteral(
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = Seq.empty
   def isDerivedFromData: Boolean = true
-  def export(builder: CodeBuilder): Unit = ()
+  def export(builder: StanProgramBuilder): Unit = ()
   def emit: String = value.toString
 }
 
@@ -458,7 +458,7 @@ sealed trait StanUnknown[T <: StanType] extends StanValue[T] {
   def outputs: Seq[StanDeclaration[_ <: StanType]] = Seq.empty
   def children: Seq[StanValue[_ <: StanType]] = Seq.empty
   def isDerivedFromData: Boolean = true
-  def export(builder: CodeBuilder): Unit = ()
+  def export(builder: StanProgramBuilder): Unit = ()
   def emit: String = ""
 }
 

--- a/src/main/scala/com/cibo/scalastan/models/LinearRegression.scala
+++ b/src/main/scala/com/cibo/scalastan/models/LinearRegression.scala
@@ -11,7 +11,68 @@
 package com.cibo.scalastan.models
 
 import com.cibo.scalastan._
-import com.cibo.scalastan.run.{StanCompiler, StanRunner}
+import com.cibo.scalastan.ast.{StanDataDeclaration, StanParameterDeclaration, StanValue}
+import com.cibo.scalastan.run.StanCompiler
+
+object LinearRegression extends ScalaStan {
+
+  // Common linear regression declarations.
+  trait RegressionDeclarations extends Model {
+    val n: StanDataDeclaration[StanInt] = data(int(lower = 0))
+    val p: StanDataDeclaration[StanInt] = data(int(lower = 0))
+    val x: StanDataDeclaration[StanMatrix] = data(matrix(n, p))
+    val y: StanDataDeclaration[StanVector] = data(vector(n))
+    val beta: StanParameterDeclaration[StanVector] = parameter(vector(p))
+    val beta0: StanParameterDeclaration[StanReal] = parameter(real())
+
+    def estimate: StanValue[StanVector] = x * beta + beta0
+  }
+
+  // Linear regression by minimizing the squared error.
+  trait LeastSquaresRegression extends RegressionDeclarations {
+    target += -stan.dot_self(y - estimate)
+  }
+
+  // Bayesian linear regression.
+  trait BayesianRegression extends RegressionDeclarations {
+    val sigma: StanParameterDeclaration[StanReal] = parameter(real(lower = 0.0))
+    y ~ stan.normal(estimate, sigma)
+  }
+
+  // Ridge penalty (penalize the Euclidean length of the coefficients).
+  trait RidgePenalty extends RegressionDeclarations {
+    val ridgeLambda: StanDataDeclaration[StanReal] = data(real(lower = 0.0))
+    target += -ridgeLambda * stan.dot_self(beta)
+  }
+
+  // Normal prior on predictors.
+  trait NormalPrior extends RegressionDeclarations {
+    val priorSigma: StanValue[StanReal] = 1.0
+    beta ~ stan.normal(0, priorSigma)
+  }
+
+  // Horseshoe prior on predictors (for sparsity).
+  trait HorseshoePrior extends RegressionDeclarations {
+    val lambda: StanParameterDeclaration[StanVector] = parameter(vector(p, lower = 0.0))  // Local shrinkage
+    val tau: StanParameterDeclaration[StanReal] = parameter(real(lower = 0.0))            // Global shrinkage
+
+    beta ~ stan.normal(0, stan.square(lambda * tau))
+    lambda ~ stan.cauchy(0, 1)
+  }
+
+  // Lasso penalty (penalize the sum of the absolute coefficients).
+  trait LassoPenalty extends RegressionDeclarations {
+    val lassoLambda: StanDataDeclaration[StanReal] = data(real(lower = 0.0))
+
+    for (i <- beta.range) {
+      target += -lassoLambda * stan.fabs(beta(i))
+    }
+  }
+
+  // ElasticNet combines LeastSquares regression with the Lasso and Ridge penalties.
+  trait ElasticNet extends LeastSquaresRegression with RidgePenalty with LassoPenalty
+
+}
 
 case class LinearRegression(
   xs: Seq[Seq[Double]],   // Inputs
@@ -20,27 +81,21 @@ case class LinearRegression(
 
   require(xs.length == ys.length, "Length of inputs must match the length of the outputs")
 
-  private val n = data(int(lower = 0))  // Number of observations
-  private val p = data(int(lower = 0))  // Number of parameters
-  private val x: DataDeclaration[StanMatrix] = data(matrix(n, p))   // Inputs
-  private val y: DataDeclaration[StanVector] = data(vector(n))      // Outputs
-
-  val beta0: ParameterDeclaration[StanReal] = parameter(real())             // Offset
-  val beta: ParameterDeclaration[StanVector] = parameter(vector(p))         // Coefficients
-  val sigma: ParameterDeclaration[StanReal] = parameter(real(lower = 0.0))  // Error
-
-  val model: Model = new Model {
+  val model: LinearRegression.BayesianRegression = new LinearRegression.BayesianRegression {
     sigma ~ stan.cauchy(0, 1)
-    y ~ stan.normal(x * beta + beta0, sigma)
   }
 
+  val beta0: StanParameterDeclaration[StanReal] = model.beta0
+  val beta: StanParameterDeclaration[StanVector] = model.beta
+  val sigma: StanParameterDeclaration[StanReal] = model.sigma
+
   def compile(implicit compiler: StanCompiler): CompiledModel = model.compile
-    .withData(x, xs)
-    .withData(y, ys)
+    .withData(model.x, xs)
+    .withData(model.y, ys)
 
   def predict(data: Seq[Seq[Double]], results: StanResults): Seq[Double] = {
-    val bestBeta0 = results.best(beta0)
-    val bestBeta = results.best(beta)
+    val bestBeta0 = results.best(model.beta0)
+    val bestBeta = results.best(model.beta)
     data.map { ds =>
       require(ds.length == bestBeta.length)
       bestBeta0 + ds.zip(bestBeta).map { case (d, b) => d * b }.sum

--- a/src/main/scala/com/cibo/scalastan/run/CmdStanRunner.scala
+++ b/src/main/scala/com/cibo/scalastan/run/CmdStanRunner.scala
@@ -204,7 +204,7 @@ class CmdStanRunner(
 
     val parameterChains = results.flatMap(_.iterations).groupBy(_._1).mapValues(_.map(_._2))
     val inverseMassMatrixDiagonals = results.map(_.inverseMassMatrixDiagonals)
-    StanResults(parameterChains, inverseMassMatrixDiagonals, compiledModel)
+    StanResults(parameterChains, inverseMassMatrixDiagonals, compiledModel, method)
   }
 }
 

--- a/src/main/scala/com/cibo/scalastan/transform/StanTransform.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/StanTransform.scala
@@ -202,6 +202,7 @@ abstract class StanTransform[STATE](implicit ss: ScalaStan) {
     case in: StanIndexOperator[_, T, _]  => handleIndexOperator(in)
     case sl: StanSliceOperator[T, _]     => handleSliceOperator(sl)
     case tr: StanTranspose[_, T]         => handleTranspose(tr)
+    case to: StanTernaryOperator[_, T]   => handleTernaryOperator(to)
     case vr: StanDeclaration[T]          => handleVariable(vr)
     case cn: StanConstant[T]             => handleConstant(cn)
     case ar: StanArrayLiteral[_, _]      => handleArray(ar)
@@ -260,6 +261,14 @@ abstract class StanTransform[STATE](implicit ss: ScalaStan) {
 
   def handleTranspose[T <: StanType, R <: StanType](tr: StanTranspose[T, R]): State[StanValue[R]] = {
     handleExpression(tr.value).map(newValue => tr.copy(value = newValue))
+  }
+
+  def handleTernaryOperator[C <: StanType, T <: StanType](to: StanTernaryOperator[C, T]): State[StanValue[T]] = {
+    for {
+      newCond <- handleExpression(to.cond)
+      newLeft <- handleExpression(to.left)
+      newRight <- handleExpression(to.right)
+    } yield to.copy(cond = newCond, left = newLeft, right = newRight)
   }
 
   def handleConstant[T <: StanType](cn: StanConstant[T]): State[StanValue[T]] = State.pure(cn)

--- a/src/test/scala/com/cibo/scalastan/ScalaStanBaseSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/ScalaStanBaseSpec.scala
@@ -36,7 +36,7 @@ trait ScalaStanBaseSpec extends FunSpec with Matchers {
         val iterations = grouped.map { case (k, v) => v }
         Vector.fill(chains)(iterations)
       }
-      StanResults(mappedData, Vector.empty, model)
+      StanResults(mappedData, Vector.empty, model, method)
     }
   }
 

--- a/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
@@ -49,7 +49,7 @@ class StanResultsSpec extends ScalaStanBaseSpec {
   val mappedData: Map[String, Vector[Vector[String]]] = Seq(testData1, testData2).flatten.groupBy(_._1).mapValues(
     grouped => Vector(grouped.map{ case(k, v) => v }.toVector)
   )
-  val results = StanResults(mappedData, Vector.empty, model)
+  val results = StanResults(mappedData, Vector.empty, model, RunMethod.Sample())
 
   describe("parameters") {
     it("returns all parameters") {

--- a/src/test/scala/com/cibo/scalastan/models/LinearRegressionSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/models/LinearRegressionSpec.scala
@@ -14,8 +14,8 @@ class LinearRegressionSpec extends ScalaStanBaseSpec {
       checkCode(model.model,
         """
            model {
-             sigma ~ cauchy(0,1);
              y ~ normal(((x) * (beta)) + (beta0),sigma);
+             sigma ~ cauchy(0,1);
            }
         """
       )


### PR DESCRIPTION
This adds support for the ternary operator using the `when` function:
```scala
   x = when(condition, ifTrue, ifFalse)
```
This builds off of the `program-builder` branch to avoid conflicts.