### PR TITLE
Add support for map_rect and fix array arguments.

### DIFF
--- a/src/it/scala/com/cibo/scalastan/examples/MapRectExample.scala
+++ b/src/it/scala/com/cibo/scalastan/examples/MapRectExample.scala
@@ -1,0 +1,50 @@
+package com.cibo.scalastan.examples
+
+import com.cibo.scalastan.ScalaStan
+
+object MapRectExample extends App with ScalaStan {
+
+  val n = data(int(lower = 0))
+  val x = data(real()(n, 2))
+
+  val alpha = parameter(real())
+  val beta = parameter(real())
+  val sigma = parameter(real(lower = 0.0))
+
+  val func = new Function(vector()) {
+    val phi = input(vector())
+    val theta = input(vector())
+    val x_r = input(real()())
+    val x_i = input(int()())
+
+    val r = local(vector(1))
+    r(1) := stan.normal(phi(1) + phi(2) * x_r(1), phi(3)).lpdf(x_r(2))
+    output(r)
+  }
+
+  val model = new Model {
+    val phi = local(vector(3))
+    phi(1) := alpha
+    phi(2) := beta
+    phi(3) := sigma
+
+    val theta = local(vector(0)(n))
+    val xi = local(int()(n, 0))
+
+    target += stan.sum(stan.map_rect(func, phi, theta, x, xi))
+  }
+
+  val compiledModel =model
+    .withData(x,
+      Seq(
+        Seq(1.0, 2.5),
+        Seq(3.0, 5.1),
+        Seq(4.0, 6.3),
+        Seq(5.0, 7.0)
+      )
+    )
+
+  val results = compiledModel.run()
+  results.summary(System.out)
+
+}

--- a/src/main/scala/com/cibo/scalastan/ScalaStan.scala
+++ b/src/main/scala/com/cibo/scalastan/ScalaStan.scala
@@ -90,7 +90,7 @@ trait ScalaStan extends Implicits with LazyLogging { ss =>
   ): StanReal = StanReal(StanUnknown.boundOpt(lower), StanUnknown.boundOpt(upper))
 
   def vector(
-    dim: StanValue[StanInt],
+    dim: StanValue[StanInt] = StanUnknownInt,
     lower: StanValue[StanReal] = StanUnknownReal,
     upper: StanValue[StanReal] = StanUnknownReal
   ): StanVector = StanVector(dim, StanUnknown.boundOpt(lower), StanUnknown.boundOpt(upper))

--- a/src/main/scala/com/cibo/scalastan/StanFunctions.scala
+++ b/src/main/scala/com/cibo/scalastan/StanFunctions.scala
@@ -594,4 +594,26 @@ protected trait StanFunctions {
     )
   }
 
+  /** Rectangular map (section 9.3). This is available as of CmdStan 2.18.0. */
+  def map_rect(
+    f: ScalaStan#Function[StanVector],
+    phi: StanValue[StanVector],
+    theta: StanValue[StanArray[StanVector]],
+    x_r: StanValue[StanArray[StanArray[StanReal]]],
+    x_i: StanValue[StanArray[StanArray[StanInt]]]
+  )(implicit code: CodeBuilder): StanValue[StanVector] = {
+    f.export(code)
+    StanCall(
+      StanVector(theta.returnType.dim),
+      "map_rect",
+      Seq(
+        StanLiteral(f.result.emit),
+        phi,
+        theta,
+        x_r,
+        x_i
+      )
+    )
+  }
+
 }

--- a/src/test/scala/com/cibo/scalastan/FunctionSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/FunctionSpec.scala
@@ -1,30 +1,40 @@
 package com.cibo.scalastan
 
-class FunctionSpec extends ScalaStanBaseSpec {
+class FunctionSpec extends ScalaStanBaseSpec with ScalaStan {
   describe("Function") {
     it("should create simple functions") {
-      new ScalaStan {
-        val f = new Function(real()) {
-          output(5)
-        }
-        val model = new Model {
-          local(real()) := f()
-        }
-        checkCode(model, "functions { real f() { return 5.0; }")
+      val f = new Function(real()) {
+        output(5.0)
       }
+      val model = new Model {
+        local(real()) := f()
+      }
+      checkCode(model, "functions { real f() { return 5.0; }")
     }
 
     it("should create functions with parameters") {
-      new ScalaStan {
-        val f = new Function() {
-          val i = input(real())
-          stan.print(i)
-        }
-        val model = new Model {
-          f(5)
-        }
-        checkCode(model, "functions { void f(real i) { print(i); } } model { f(5); }")
+      val f = new Function() {
+        val i = input(real())
+        stan.print(i)
       }
+      val model = new Model {
+        f(5)
+      }
+      checkCode(model, "functions { void f(real i) { print(i); } } model { f(5); }")
+    }
+
+    it("should create functions with vector parameters") {
+      val f = new Function(vector()) {
+        val x = input(vector())
+        val y = input(vector()())
+        output(x)
+      }
+      val model = new Model {
+        val x = local(vector(5))
+        val y = local(vector(5)(7))
+        local(vector(5)) := f(x, y)
+      }
+      checkCode(model, "functions { vector f(vector x, vector[] y) { return x; } }")
     }
   }
 }


### PR DESCRIPTION
This adds support for the `map_rect` function that was introduced in CmdStan 2.18.0.  This also fixes an issue with function declarations not working correctly with vectors etc.