### PR TITLE
Fix an issue with parens and indexing.

### DIFF
--- a/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
@@ -292,7 +292,7 @@ case class StanUnaryOperator[T <: StanType, R <: StanType](
   def children: Seq[StanValue[_ <: StanType]] = Seq(right)
   def isDerivedFromData: Boolean = right.isDerivedFromData
   def export(builder: CodeBuilder): Unit = right.export(builder)
-  def emit: String = s"${op.name}(${right.emit})"
+  def emit: String = s"(${op.name}${right.emit})"
 }
 
 object StanUnaryOperator {
@@ -306,7 +306,6 @@ case class StanBinaryOperator[T <: StanType, L <: StanType, R <: StanType](
   returnType: T,
   left: StanValue[L],
   right: StanValue[R],
-  parens: Boolean = true,
   id: Int = StanNode.getNextId
 ) extends StanValue[T] {
   def inputs: Seq[StanDeclaration[_ <: StanType]] = left.inputs ++ right.inputs
@@ -317,12 +316,7 @@ case class StanBinaryOperator[T <: StanType, L <: StanType, R <: StanType](
     left.export(builder)
     right.export(builder)
   }
-  def emit: String =
-    if (parens) {
-      s"(${left.emit}) ${op.name} (${right.emit})"
-    } else {
-      s"${left.emit} ${op.name} ${right.emit}"
-    }
+  def emit: String = s"(${left.emit} ${op.name} ${right.emit})"
 }
 
 object StanBinaryOperator {
@@ -395,7 +389,7 @@ case class StanTranspose[T <: StanType, R <: StanType](
   def export(builder: CodeBuilder): Unit = {
     value.export(builder)
   }
-  def emit: String = s"(${value.emit})'"
+  def emit: String = s"${value.emit}'"
 }
 
 case class StanConstant[T <: StanType](

--- a/src/test/scala/com/cibo/scalastan/ScalaStanSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/ScalaStanSpec.scala
@@ -171,7 +171,7 @@ class ScalaStanSpec extends ScalaStanBaseSpec {
           val model = new Model {
             local(real()) := local(real()) + local(int())
           }
-          checkCode(model, "ss_v# = (ss_v#) + (ss_v#);")
+          checkCode(model, "ss_v# = (ss_v# + ss_v#);")
         }
       }
 
@@ -180,7 +180,7 @@ class ScalaStanSpec extends ScalaStanBaseSpec {
           val model = new Model {
             local(real()) := local(real()) - local(int())
           }
-          checkCode(model, "ss_v# = (ss_v#) - (ss_v#);")
+          checkCode(model, "ss_v# = (ss_v# - ss_v#);")
         }
       }
 
@@ -189,7 +189,7 @@ class ScalaStanSpec extends ScalaStanBaseSpec {
           val model = new Model {
             local(real()) := local(real()) * local(int())
           }
-          checkCode(model, "ss_v# = (ss_v#) * (ss_v#);")
+          checkCode(model, "ss_v# = (ss_v# * ss_v#);")
         }
       }
 
@@ -198,7 +198,7 @@ class ScalaStanSpec extends ScalaStanBaseSpec {
           val model = new Model {
             local(real()) := local(real()) / local(int())
           }
-          checkCode(model, "ss_v# = (ss_v#) / (ss_v#);")
+          checkCode(model, "ss_v# = (ss_v# / ss_v#);")
         }
       }
 
@@ -208,7 +208,7 @@ class ScalaStanSpec extends ScalaStanBaseSpec {
             val n = local(int())
             local(matrix(n, n)) := local(matrix(n, n)) \ local(matrix(n, n))
           }
-          checkCode(model, "ss_v# = (ss_v#) \\ (ss_v#);")
+          checkCode(model, "ss_v# = (ss_v# \\ ss_v#);")
         }
       }
 
@@ -217,7 +217,7 @@ class ScalaStanSpec extends ScalaStanBaseSpec {
           val model = new Model {
             local(real()) := local(real()) ^ local(int())
           }
-          checkCode(model, "ss_v# = (ss_v#) ^ (ss_v#);")
+          checkCode(model, "ss_v# = (ss_v# ^ ss_v#);")
         }
       }
 
@@ -226,7 +226,7 @@ class ScalaStanSpec extends ScalaStanBaseSpec {
           val model = new Model {
             local(int()) := local(int()) % local(int())
           }
-          checkCode(model, "ss_v# = (ss_v#) % (ss_v#);")
+          checkCode(model, "ss_v# = (ss_v# % ss_v#);")
         }
       }
 
@@ -236,7 +236,7 @@ class ScalaStanSpec extends ScalaStanBaseSpec {
             val n = local(int())
             local(matrix(n, n)) := local(matrix(n, n)).t
           }
-          checkCode(model, "ss_v# = (ss_v#)';")
+          checkCode(model, "ss_v# = ss_v#';")
         }
       }
 

--- a/src/test/scala/com/cibo/scalastan/TransformedParameterSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/TransformedParameterSpec.scala
@@ -60,7 +60,7 @@ class TransformedParameterSpec extends ScalaStanBaseSpec with ScalaStan {
         result := 0.1
       }
       val model = new Model { local(real()) := pt }
-      checkCode(model, "transformed parameters { real<lower=(1) / (d)> pt; { pt = 0.1; } }")
+      checkCode(model, "transformed parameters { real<lower=(1 / d)> pt; { pt = 0.1; } }")
     }
 
     it("should preserve transformed parameters used in conditionals") {

--- a/src/test/scala/com/cibo/scalastan/ast/StanValueSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/ast/StanValueSpec.scala
@@ -1,6 +1,7 @@
 package com.cibo.scalastan.ast
 
 import com.cibo.scalastan._
+import scala.language.existentials
 
 class StanValueSpec extends ScalaStanBaseSpec {
 
@@ -10,59 +11,59 @@ class StanValueSpec extends ScalaStanBaseSpec {
     describe("ints") {
       it("can add int + const_int") {
         val r = StanConstant[StanInt](StanInt(), 1) + 3
-        r.emit shouldBe "(1) + (3)"
+        r.emit shouldBe "(1 + 3)"
       }
       it("can add const_int + int") {
         import com.cibo.scalastan.Implicits._
         val r = 2 + StanConstant[StanInt](StanInt(), 1)
-        r.emit shouldBe "(2) + (1)"
+        r.emit shouldBe "(2 + 1)"
       }
       it("can add int + int") {
         val r = StanConstant[StanInt](StanInt(), 1) + StanConstant[StanInt](StanInt(), 2)
-        r.emit shouldBe "(1) + (2)"
+        r.emit shouldBe "(1 + 2)"
       }
     }
 
     describe("ints and doubles") {
       it("can add double + const_int") {
         val r = StanConstant[StanReal](StanReal(), 1) + 3
-        r.emit shouldBe "(1.0) + (3)"
+        r.emit shouldBe "(1.0 + 3)"
       }
       it("can add const_int + double") {
         import com.cibo.scalastan.Implicits._
         val r = 2 + StanConstant[StanReal](StanReal(), 1)
-        r.emit shouldBe "(2) + (1.0)"
+        r.emit shouldBe "(2 + 1.0)"
       }
       it("can add int + double") {
         val r = StanConstant[StanInt](StanInt(), 1) + StanConstant[StanReal](StanReal(), 2)
-        r.emit shouldBe "(1) + (2.0)"
+        r.emit shouldBe "(1 + 2.0)"
       }
       it("can add double + int") {
         val r = StanConstant[StanReal](StanReal(), 1) + StanConstant[StanInt](StanInt(), 2)
-        r.emit shouldBe "(1.0) + (2)"
+        r.emit shouldBe "(1.0 + 2)"
       }
     }
 
     describe("doubles") {
       it("can add double + const_double") {
         val r = StanConstant[StanReal](StanReal(), 1) + 3.0
-        r.emit shouldBe "(1.0) + (3.0)"
+        r.emit shouldBe "(1.0 + 3.0)"
       }
       it("can add const_double + double") {
         import com.cibo.scalastan.Implicits._
         val r = 2.0 + StanConstant[StanReal](StanReal(), 1)
-        r.emit shouldBe "(2.0) + (1.0)"
+        r.emit shouldBe "(2.0 + 1.0)"
       }
       it("can add double + double") {
         val r = StanConstant[StanReal](StanReal(), 1) + StanConstant[StanReal](StanReal(), 2)
-        r.emit shouldBe "(1.0) + (2.0)"
+        r.emit shouldBe "(1.0 + 2.0)"
       }
     }
 
     describe("vectors and ints") {
       it("can add vector + const_int") {
         val r = StanLocalDeclaration[StanVector](StanVector(StanConstant[StanInt](StanInt(), 1)), "x") + 1
-        check(r.emit, "(x) + (1)")
+        check(r.emit, "(x + 1)")
       }
     }
   }
@@ -70,7 +71,7 @@ class StanValueSpec extends ScalaStanBaseSpec {
   describe("*") {
     it("can multiply doubles") {
       val r = StanConstant[StanReal](StanReal(), 1) * 3.0
-      r.emit shouldBe "(1.0) * (3.0)"
+      r.emit shouldBe "(1.0 * 3.0)"
     }
 
     it("can multiply matrices") {
@@ -79,7 +80,7 @@ class StanValueSpec extends ScalaStanBaseSpec {
         "mat"
       )
       val r = mat * mat
-      r.emit shouldBe "(mat) * (mat)"
+      r.emit shouldBe "(mat * mat)"
     }
   }
 
@@ -87,19 +88,19 @@ class StanValueSpec extends ScalaStanBaseSpec {
     it("can divide vectors") {
       val n = StanLocalDeclaration(StanInt(), "n")
       val r = StanLocalDeclaration(StanVector(n), "x") /:/ StanLocalDeclaration(StanVector(n), "y")
-      check(r.emit, "(x) ./ (y)")
+      check(r.emit, "(x ./ y)")
     }
 
     it("can divide scalar by vector") {
       val n = StanLocalDeclaration(StanInt(), "n")
       val r = n /:/ StanLocalDeclaration(StanVector(n), "x")
-      check(r.emit, "(n) ./ (x)")
+      check(r.emit, "(n ./ x)")
     }
 
     it("can divide matrix by scalar") {
       val n = StanLocalDeclaration(StanInt(), "n")
       val r = StanLocalDeclaration(StanMatrix(n, n), "x") /:/ n
-      check(r.emit, "(x) ./ (n)")
+      check(r.emit, "(x ./ n)")
     }
 
     it("can not divide scalar by scalar") {
@@ -111,22 +112,22 @@ class StanValueSpec extends ScalaStanBaseSpec {
   describe("^") {
     it("can pow ints") {
       val r = StanConstant[StanInt](StanInt(), 1) ^ StanConstant[StanInt](StanInt(), 2)
-      r.emit shouldBe "(1) ^ (2)"
+      r.emit shouldBe "(1 ^ 2)"
     }
     it("can pow real / int") {
       val r = StanConstant[StanReal](StanReal(), 1.0) ^ StanConstant[StanInt](StanInt(), 2)
-      r.emit shouldBe "(1.0) ^ (2)"
+      r.emit shouldBe "(1.0 ^ 2)"
     }
     it("can pow reals") {
       val r = StanConstant[StanReal](StanReal(), 1.0) ^ StanConstant[StanReal](StanReal(), 2.0)
-      r.emit shouldBe "(1.0) ^ (2.0)"
+      r.emit shouldBe "(1.0 ^ 2.0)"
     }
   }
 
   describe("unary -") {
     it("can negate ints") {
       val r = -StanConstant[StanInt](StanInt(), 1)
-      r.emit shouldBe "-(1)"
+      r.emit shouldBe "(-1)"
     }
   }
 
@@ -247,6 +248,15 @@ class StanValueSpec extends ScalaStanBaseSpec {
       val i = StanDataDeclaration[StanArray[StanInt]](StanArray(n, StanInt()), "i")
       val vec = StanDataDeclaration[StanArray[StanReal]](StanArray(n, StanReal()), "vec")
       vec(i).emit shouldBe "vec[i]"
+    }
+  }
+
+  describe("indexed expression") {
+    it("can index into an expression") {
+      val n = StanDataDeclaration[StanInt](StanInt(), "n")
+      val v = StanDataDeclaration[StanVector](StanVector(n), "v")
+      val expression = (v + 1.0).apply(2)
+      expression.emit shouldBe "(v + 1.0)[2]"
     }
   }
 }

--- a/src/test/scala/com/cibo/scalastan/models/LinearRegressionSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/models/LinearRegressionSpec.scala
@@ -15,7 +15,7 @@ class LinearRegressionSpec extends ScalaStanBaseSpec {
         """
            model {
              sigma ~ cauchy(0,1);
-             y ~ normal(((x) * (beta)) + (beta0),sigma);
+             y ~ normal(((x * beta) + beta0),sigma);
            }
         """
       )

--- a/src/test/scala/com/cibo/scalastan/transform/CSESpec.scala
+++ b/src/test/scala/com/cibo/scalastan/transform/CSESpec.scala
@@ -16,7 +16,7 @@ class CSESpec extends ScalaStanBaseSpec {
         val updated = model.transform(CSE())
       }
 
-      checkCode(Test.updated, "model { real z; real y; real x; x = (y) + (1); z = x; }")
+      checkCode(Test.updated, "model { real z; real y; real x; x = (y + 1); z = x; }")
     }
 
     it("re-orders multiplication") {
@@ -31,7 +31,7 @@ class CSESpec extends ScalaStanBaseSpec {
         val updated = model.transform(CSE())
       }
 
-      checkCode(Test.updated, "model { real z; real y; real x; x = (y) * (1); z = x; }")
+      checkCode(Test.updated, "model { real z; real y; real x; x = (y * 1); z = x; }")
     }
 
     it("does not re-order division") {
@@ -46,7 +46,7 @@ class CSESpec extends ScalaStanBaseSpec {
         val updated = model.transform(CSE())
       }
 
-      checkCode(Test.updated, "model { real z; real y; real x; x = (y) / (1); z = (1) / (y); }")
+      checkCode(Test.updated, "model { real z; real y; real x; x = (y / 1); z = (1 / y); }")
     }
   }
 }

--- a/src/test/scala/com/cibo/scalastan/transform/StrengthReductionSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/transform/StrengthReductionSpec.scala
@@ -34,7 +34,7 @@ class StrengthReductionSpec extends ScalaStanBaseSpec with ScalaStan {
         val c = local(real())
         x := a * b * c
       }
-      checkCode(model.transform(StrengthReduction()), "x = ((a) * (b)) * (c)")
+      checkCode(model.transform(StrengthReduction()), "x = ((a * b) * c)")
     }
   }
 


### PR DESCRIPTION
This changes the way parenthesis are emitted to be like `(x + y)` instead of `(x) + (y)`.  The reason for this change is to fix a potential issue with indexing.  For example, the expression `(x + y)(5)` in Scala should turn into `(x + y)[5]` now instead of `(x) + (y)[5]`.