### PR TITLE
Some small improvements

### DIFF
--- a/src/it/scala/com/cibo/scalastan/examples/AlgebraSolverExample.scala
+++ b/src/it/scala/com/cibo/scalastan/examples/AlgebraSolverExample.scala
@@ -1,0 +1,44 @@
+package com.cibo.scalastan.examples
+
+import com.cibo.scalastan.{RunMethod, StanModel}
+
+object AlgebraSolverExample extends App {
+
+  object model extends StanModel {
+
+    val system = new Function(vector()) {
+      val y = input(vector())
+      val theta = input(vector())
+      val x_r = input(real()())
+      val x_i = input(int()())
+
+      val z = local(vector(2))
+      z(1) := y(1) - theta(1)
+      z(2) := y(1) * y(2) + theta(2)
+      output(z)
+    }
+
+    val y_guess = data(vector(2))
+    val x_r = new TransformedData(real()(0)) { }
+    val x_i = new TransformedData(int()(0)) { }
+
+    val theta = new TransformedParameter(vector(2)) {
+      result(1) := 3
+      result(2) := 6
+    }
+
+    val y = new GeneratedQuantity(vector(2)) {
+      result := stan.algebra_solver(system, y_guess, theta, x_r, x_i)
+    }
+
+    val z = new GeneratedQuantity(vector(2)) {
+      result := system(y, theta, x_r, x_i)
+    }
+  }
+
+  val results = model
+    .withData(model.y_guess, Seq(1.0, 1.0))
+    .run(chains = 1, method = RunMethod.Sample(samples = 1, algorithm = RunMethod.FixedParam()))
+
+  results.summary(System.out, model.y, model.z)
+}

--- a/src/main/scala/com/cibo/scalastan/CommandRunner.scala
+++ b/src/main/scala/com/cibo/scalastan/CommandRunner.scala
@@ -14,7 +14,7 @@ import java.io.File
 
 import com.typesafe.scalalogging.LazyLogging
 
-object CommandRunner extends LazyLogging {
+trait CommandRunner extends LazyLogging {
   def runCommand(dir: File, command: Seq[String]): Int = {
     val pb = new ProcessBuilder(command: _*).directory(dir).redirectErrorStream(true)
     val process = pb.start()

--- a/src/main/scala/com/cibo/scalastan/StanCodeBlock.scala
+++ b/src/main/scala/com/cibo/scalastan/StanCodeBlock.scala
@@ -31,6 +31,19 @@ trait StanCodeBlock extends Implicits {
     decl
   }
 
+  def local[T <: StanType](
+    typeConstructor: T,
+    value: StanValue[T]
+  )(implicit name: sourcecode.Name): StanLocalDeclaration[T] = {
+    if (typeConstructor.lower.isDefined || typeConstructor.upper.isDefined) {
+      throw new IllegalStateException("local variables may not have constraints")
+    }
+
+    val decl = StanLocalDeclaration[T](typeConstructor, _context.fixName(name.value))
+    _code.insert(StanInlineDeclaration(decl, Some(value)))
+    decl
+  }
+
   case class when(cond: StanValue[StanInt])(block: => Unit) {
     _code.enter()
     block

--- a/src/main/scala/com/cibo/scalastan/StanDistributions.scala
+++ b/src/main/scala/com/cibo/scalastan/StanDistributions.scala
@@ -373,6 +373,9 @@ trait StanDistributions {
   ): StanContinuousDistribution[R, StanReal] =
     StanContinuousDistribution("skew_normal", StanReal(), args(xi, omega, alpha))
 
+  def std_normal[R <: StanType](): StanContinuousDistribution[R, StanReal] =
+    StanContinuousDistribution("std_normal", StanReal(), args())
+
   def student_t[
     N <: StanType: ContinuousType,
     M <: StanType: ContinuousType,

--- a/src/main/scala/com/cibo/scalastan/StanFunctions.scala
+++ b/src/main/scala/com/cibo/scalastan/StanFunctions.scala
@@ -256,7 +256,9 @@ trait StanFunctions {
     StanCall(StanInt(), "rank", Seq(v, s))
 
   // Integer-valued matrix size functions (42.1).
+  @deprecated("use num_elements", "2018-12-17")
   def numElements[T <: StanVectorOrMatrix](x: StanValue[T]): StanValue[StanInt] = StanCall(StanInt(), "num_elements", Seq(x))
+  def num_elements[T <: StanVectorOrMatrix](x: StanValue[T]): StanValue[StanInt] = StanCall(StanInt(), "num_elements", Seq(x))
   def rows[T <: StanVectorOrMatrix](x: StanValue[T]): StanValue[StanInt] = StanCall(StanInt(), "rows", Seq(x))
   def cols[T <: StanVectorOrMatrix](x: StanValue[T]): StanValue[StanInt] = StanCall(StanInt(), "cols", Seq(x))
 

--- a/src/main/scala/com/cibo/scalastan/StanFunctions.scala
+++ b/src/main/scala/com/cibo/scalastan/StanFunctions.scala
@@ -594,6 +594,55 @@ trait StanFunctions {
     )
   }
 
+  /** Algebraic Solver (section 47.2). */
+  def algebra_solver(
+    algebra_system: StanModel#Function[StanVector],
+    y_guess: StanValue[StanVector],
+    theta: StanValue[StanVector],
+    x_r: StanValue[StanArray[StanReal]],
+    x_i: StanValue[StanArray[StanInt]]
+  )(implicit builder: StanProgramBuilder): StanValue[StanVector] = {
+    algebra_system.export(builder)
+    StanCall(
+      y_guess.returnType,
+      "algebra_solver",
+      Seq(
+        StanLiteral(algebra_system.result.emit),
+        y_guess,
+        theta,
+        x_r,
+        x_i
+      )
+    )
+  }
+
+  def algebra_solver(
+    algebra_system: StanModel#Function[StanVector],
+    y_guess: StanValue[StanVector],
+    theta: StanValue[StanVector],
+    x_r: StanValue[StanArray[StanReal]],
+    x_i: StanValue[StanArray[StanInt]],
+    rel_tol: StanValue[StanReal],
+    f_tol: StanValue[StanReal],
+    max_steps: StanValue[StanInt]
+  )(implicit builder: StanProgramBuilder): StanValue[StanVector] = {
+    algebra_system.export(builder)
+    StanCall(
+      y_guess.returnType,
+      "algebra_solver",
+      Seq(
+        StanLiteral(algebra_system.result.emit),
+        y_guess,
+        theta,
+        x_r,
+        x_i,
+        rel_tol,
+        f_tol,
+        max_steps
+      )
+    )
+  }
+
   /** Rectangular map (section 9.3). This is available as of CmdStan 2.18.0. */
   def map_rect(
     f: StanModel#Function[StanVector],

--- a/src/main/scala/com/cibo/scalastan/StanFunctions.scala
+++ b/src/main/scala/com/cibo/scalastan/StanFunctions.scala
@@ -435,6 +435,16 @@ trait StanFunctions {
     b: StanValue[StanMatrix]
   ): StanValue[T] = StanCall(a.returnType, "mdivide_right_spd", Seq(a, b))
   def matrix_exp(a: StanValue[StanMatrix]): StanValue[StanMatrix] = StanCall(a.returnType, "matrix_exp", Seq(a))
+  def matrix_exp_multiply(a: StanValue[StanMatrix], b: StanValue[StanMatrix]): StanValue[StanMatrix] = {
+    StanCall(StanMatrix(a.returnType.rows, b.returnType.cols), "matrix_exp_multiply", Seq(a, b))
+  }
+  def scale_matrix_exp_multiply(
+    t: StanValue[StanReal],
+    a: StanValue[StanMatrix],
+    b: StanValue[StanMatrix]
+  ): StanValue[StanMatrix] = {
+    StanCall(StanMatrix(a.returnType.rows, b.returnType.cols), "scale_matrix_exp_multiply", Seq(t, a, b))
+  }
   def trace(a: StanValue[StanMatrix]): StanValue[StanReal] = StanCall(StanReal(), "trace", Seq(a))
   def determinant(a: StanValue[StanMatrix]): StanValue[StanReal] = StanCall(StanReal(), "determinant", Seq(a))
   def log_determinant(a: StanValue[StanMatrix]): StanValue[StanReal] = StanCall(StanReal(), "log_determinant", Seq(a))
@@ -443,8 +453,17 @@ trait StanFunctions {
   def eigenvalues_sym(a: StanValue[StanMatrix]): StanValue[StanVector] =
     StanCall(StanVector(a.returnType.rows), "eigenvalues_sym", Seq(a))
   def eigenvectors_sym(a: StanValue[StanMatrix]): StanValue[StanMatrix] = StanCall(a.returnType, "eigenvectors_sym", Seq(a))
-  def qr_Q(a: StanValue[StanMatrix]): StanValue[StanMatrix] = StanCall(a.returnType, "qr_Q", Seq(a))
-  def qr_R(a: StanValue[StanMatrix]): StanValue[StanMatrix] = StanCall(a.returnType, "qr_R", Seq(a))
+
+  def qr_thin_Q(a: StanValue[StanMatrix]): StanValue[StanMatrix] = StanCall(a.returnType, "qr_thin_Q", Seq(a))
+  def qr_thin_R(a: StanValue[StanMatrix]): StanValue[StanMatrix] = {
+    StanCall(StanMatrix(a.returnType.cols, a.returnType.cols), "qr_thin_R", Seq(a))
+  }
+  def qr_Q(a: StanValue[StanMatrix]): StanValue[StanMatrix] = {
+    StanCall(StanMatrix(a.returnType.rows, a.returnType.rows), "qr_Q", Seq(a))
+  }
+  def qr_R(a: StanValue[StanMatrix]): StanValue[StanMatrix] = {
+    StanCall(StanMatrix(a.returnType.rows, a.returnType.rows), "qr_R", Seq(a))
+  }
   def cholesky_decompose(a: StanValue[StanMatrix]): StanValue[StanMatrix] = StanCall(a.returnType, "cholesky_decompose", Seq(a))
   def singular_values(a: StanValue[StanMatrix]): StanValue[StanVector] =
     StanCall(StanVector(a.returnType.rows), "singular_values", Seq(a))

--- a/src/main/scala/com/cibo/scalastan/StanResults.scala
+++ b/src/main/scala/com/cibo/scalastan/StanResults.scala
@@ -32,12 +32,11 @@ case class StanResults(
   private val acceptName = "accept_stat__"
   private val stepSizeName = "stepsize__"
 
-  lazy val bestChain: Int = parameterChains(lpName).zipWithIndex.maxBy(_._1.map(_.toDouble).max)._2
-  lazy val bestIndex: Int = parameterChains(lpName)(bestChain).zipWithIndex.maxBy(_._1.toDouble)._2
+  lazy val bestChain: Int = parameterChains(lpName).zipWithIndex.maxBy(_._1.max)._2
+  lazy val bestIndex: Int = parameterChains(lpName)(bestChain).zipWithIndex.maxBy(_._1)._2
 
-  private def extract(name: String): Seq[Seq[Double]] = parameterChains(name).map(_.map(_.toDouble))
-  private def extractOption(name: String): Seq[Seq[Double]] =
-    parameterChains.getOrElse(name, Seq.empty).map(_.map(_.toDouble))
+  private def extract(name: String): Seq[Seq[Double]] = parameterChains(name)
+  private def extractOption(name: String): Seq[Seq[Double]] = parameterChains.getOrElse(name, Seq.empty)
 
   lazy val logPosterior: Seq[Seq[Double]] = extract(lpName)
   lazy val divergent: Seq[Seq[Double]] = extractOption(divergentName)
@@ -348,7 +347,7 @@ case class StanResults(
     val names = parameterChains.keys
     val results: Seq[(String, Seq[Seq[Double]])] = names.par.flatMap { name =>
       cleanName(name, mapping).map { cleanedName =>
-        cleanedName -> parameterChains(name).map(_.map(i => Try(i.toDouble).getOrElse(Double.NaN)))
+        cleanedName -> parameterChains(name)
       }
     }.toVector.sortBy(_._1)
 

--- a/src/main/scala/com/cibo/scalastan/StanResults.scala
+++ b/src/main/scala/com/cibo/scalastan/StanResults.scala
@@ -17,7 +17,7 @@ import com.cibo.scalastan.ast.{StanDataDeclaration, StanParameterDeclaration}
 import scala.util.Try
 
 case class StanResults(
-  parameterChains: Map[String, Vector[Vector[String]]],
+  parameterChains: Map[String, Vector[Vector[Double]]],
   massMatrix: Vector[Vector[Vector[Double]]],
   model: CompiledModel,
   method: RunMethod.Method

--- a/src/main/scala/com/cibo/scalastan/run/CmdStanCompiler.scala
+++ b/src/main/scala/com/cibo/scalastan/run/CmdStanCompiler.scala
@@ -17,7 +17,7 @@ import java.util.regex.Pattern
 import com.cibo.scalastan._
 import com.typesafe.scalalogging.LazyLogging
 
-object CmdStanCompiler extends StanCompiler with LazyLogging {
+object CmdStanCompiler extends StanCompiler with CommandRunner with LazyLogging {
 
   lazy val CMDSTAN_HOME: Option[String] = sys.env.get("CMDSTAN_HOME")
   val modelExecutable: String = "model"
@@ -62,7 +62,7 @@ object CmdStanCompiler extends StanCompiler with LazyLogging {
     val stancCommand = stanc.getOrElse {
       throw new IllegalStateException(s"Could not locate stanc.")
     }
-    val rc = CommandRunner.runCommand(dir, Seq(stancCommand, stanFileName))
+    val rc = runCommand(dir, Seq(stancCommand, stanFileName))
     if (rc != 0) {
       throw new IllegalStateException(s"$stanc returned $rc")
     }
@@ -76,7 +76,7 @@ object CmdStanCompiler extends StanCompiler with LazyLogging {
     val stanPath = stanHome.getOrElse {
       throw new IllegalStateException("Could not locate Stan.")
     }
-    val rc = CommandRunner.runCommand(new File(stanPath), Seq(makeCommand, target))
+    val rc = runCommand(new File(stanPath), Seq(makeCommand, target))
     if (rc != 0) {
       throw new IllegalStateException(s"$make returned $rc")
     }

--- a/src/main/scala/com/cibo/scalastan/run/CmdStanCompiler.scala
+++ b/src/main/scala/com/cibo/scalastan/run/CmdStanCompiler.scala
@@ -102,8 +102,10 @@ object CmdStanCompiler extends StanCompiler with LazyLogging {
       dirs.foreach { dir =>
         logger.info(s"removing old cache directory ${dir.getAbsolutePath}")
         try {
-          dir.listFiles.foreach(_.delete())
-          dir.delete()
+          Option(dir.listFiles).map { files =>
+            files.foreach(_.delete())
+            dir.delete()
+          }
         } catch {
           case ex: Exception =>
             logger.warn("unable to remove cache directory", ex)

--- a/src/main/scala/com/cibo/scalastan/run/CmdStanRunner.scala
+++ b/src/main/scala/com/cibo/scalastan/run/CmdStanRunner.scala
@@ -67,7 +67,7 @@ class CmdStanRunner(
   private val dataPrefix: String = "input"
 
   case class ChainResult(
-    iterations: Map[String, Vector[String]],
+    iterations: Map[String, Vector[Double]],
     massMatrix: Vector[Vector[Double]]
   )
 
@@ -149,8 +149,8 @@ class CmdStanRunner(
       val rawLines = reader.lines.iterator.asScala.toVector
       val lines = rawLines.filterNot(_.startsWith("#"))
       if (lines.nonEmpty) {
-        val header = lines.head.split(',').toVector
-        val columns = lines.tail.map(_.split(',').toVector).transpose
+        val header = lines.head.split(',')
+        val columns = lines.tail.map(_.split(',').map(_.toDouble)).transpose
         ChainResult(header.zip(columns).toMap, loadMassMatrix(rawLines))
       } else {
         ChainResult(Map.empty, Vector.empty)

--- a/src/main/scala/com/cibo/scalastan/run/CmdStanRunner.scala
+++ b/src/main/scala/com/cibo/scalastan/run/CmdStanRunner.scala
@@ -28,7 +28,7 @@ case class CmdStanChainContext(
   initialValueFile: Option[File],
   chainSeed: Int,
   runHash: String
-) extends LazyLogging {
+) extends CommandRunner with LazyLogging {
 
   def initialValueArguments: Vector[String] = compiledModel.initialValue match {
     case DefaultInitialValue => Vector.empty
@@ -45,7 +45,7 @@ case class CmdStanChainContext(
       "random", s"seed=$chainSeed"
     ) ++ initialValueArguments ++ method.arguments
     logger.info("Running " + command.mkString(" "))
-    val rc = CommandRunner.runCommand(modelDir, command)
+    val rc = runCommand(modelDir, command)
     if (rc == 0) {
       Files.move(temp.toPath, outputFile.toPath, StandardCopyOption.ATOMIC_MOVE)
     } else {

--- a/src/main/scala/com/cibo/scalastan/run/CmdStanRunner.scala
+++ b/src/main/scala/com/cibo/scalastan/run/CmdStanRunner.scala
@@ -170,7 +170,7 @@ class CmdStanRunner(
     val rc = context.run()
     if (rc != 0) {
       logger.error(s"model returned $rc")
-      None
+      throw new StanException(rc)
     } else {
       Some(readIterations(context.outputFile))
     }

--- a/src/main/scala/com/cibo/scalastan/run/StanException.scala
+++ b/src/main/scala/com/cibo/scalastan/run/StanException.scala
@@ -1,0 +1,24 @@
+package com.cibo.scalastan.run
+
+class StanException(val errorCode: Int) extends Exception(s"error $errorCode: ${StanException.getMessage(errorCode)}")
+
+object StanException {
+  object ErrorCodes {
+    val ok: Int = 0
+    val usage: Int = 64
+    val dataError: Int = 65
+    val noInput: Int = 66
+    val software: Int = 70
+    val config: Int = 78
+  }
+
+  def getMessage(errorCode: Int): String = errorCode match {
+    case ErrorCodes.ok        => "success"
+    case ErrorCodes.usage     => "command used incorrectly"
+    case ErrorCodes.dataError => "input data is invalid"
+    case ErrorCodes.noInput   => "no input"
+    case ErrorCodes.software  => "internal error"
+    case ErrorCodes.config    => "bad configuration"
+    case _                    => "unknown"
+  }
+}

--- a/src/test/scala/com/cibo/scalastan/ScalaStanBaseSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/ScalaStanBaseSpec.scala
@@ -8,31 +8,31 @@ import org.scalatest.{FunSpec, Matchers}
 
 trait ScalaStanBaseSpec extends FunSpec with Matchers {
 
-  case class MockRunner(data: Vector[Map[String, String]] = Vector.empty) extends StanRunner {
+  case class MockRunner(data: Vector[Map[String, Double]] = Vector.empty) extends StanRunner {
 
     private val results = scala.collection.mutable.ArrayBuffer[(String, Vector[Vector[String]])]()
 
-    private def set(prefix: String, values: Any, mapping: Map[String, String]): Map[String, String] = {
+    private def set(prefix: String, values: Any, mapping: Map[String, Double]): Map[String, Double] = {
       values match {
         case s: Seq[_] =>
           s.zipWithIndex.foldLeft(mapping) { case (m, (v, i)) =>
             set(s"$prefix.${i + 1}", v, m)
           }
-        case _ => mapping + (prefix -> values.toString)
+        case _ => mapping + (prefix -> values.asInstanceOf[Double])
       }
     }
 
 
     def set[T <: StanType](decl: StanParameterDeclaration[T], values: Seq[T#SCALA_TYPE]): MockRunner = {
       require(data.isEmpty || data.length == values.length)
-      val dataBefore = if (data.isEmpty) values.map(_ => Map[String, String]("lp__" -> "1")) else data
+      val dataBefore = if (data.isEmpty) values.map(_ => Map[String, Double]("lp__" -> 1)) else data
       val prefix = decl.emit
       val newData = values.zip(dataBefore).map { case (v, d) => set(prefix, v, d) }
       copy(data = newData.toVector)
     }
 
     def run(model: CompiledModel, chains: Int, seed: Int, cache: Boolean, method: RunMethod.Method): StanResults = {
-      val mappedData: Map[String, Vector[Vector[String]]] = data.flatten.groupBy(_._1).mapValues { grouped =>
+      val mappedData: Map[String, Vector[Vector[Double]]] = data.flatten.groupBy(_._1).mapValues { grouped =>
         val iterations = grouped.map { case (k, v) => v }
         Vector.fill(chains)(iterations)
       }

--- a/src/test/scala/com/cibo/scalastan/StanDistributionsSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/StanDistributionsSpec.scala
@@ -96,4 +96,23 @@ class StanDistributionsSpec extends ScalaStanBaseSpec {
       checkCode(model, "y[1] ~ multi_normal(mu, sigma);")
     }
   }
+
+  describe("std_normal") {
+    it("should work") {
+      val model = new StanModel {
+        val y = data(real())
+        y ~ stan.std_normal()
+      }
+      checkCode(model, "y ~ std_normal();")
+    }
+
+    it("should vectorize") {
+      val model = new StanModel {
+        val n = data(int())
+        val y = data(vector(n))
+        y ~ stan.std_normal()
+      }
+      checkCode(model, "y ~ std_normal();")
+    }
+  }
 }

--- a/src/test/scala/com/cibo/scalastan/StanModelSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/StanModelSpec.scala
@@ -62,6 +62,14 @@ class StanModelSpec extends ScalaStanBaseSpec {
       }
       checkCode(model, "model { for(ss_v# in 1:2) { int x; x += 1; } }")
     }
+
+    it("supports initial values") {
+      object model extends StanModel {
+        val x = local(real(), 2.5)
+        x += 1.0
+      }
+      checkCode(model, "model { real x = 2.5; x += 1.0; }")
+    }
   }
 
   describe("model") {

--- a/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/StanResultsSpec.scala
@@ -17,7 +17,7 @@ class StanResultsSpec extends ScalaStanBaseSpec {
 
   private val model = CompiledModel(TestModel, MockRunner())
 
-  private val testData1 = Map[String, Int](
+  private val testData1 = Map[String, Double](
     "lp__" -> 1,
     TestModel.v1.emit -> 1,
     s"${TestModel.v2.emit}.1" -> 2,
@@ -29,9 +29,9 @@ class StanResultsSpec extends ScalaStanBaseSpec {
     s"${TestModel.v3.emit}.2.2" -> 322,
     s"${TestModel.v3.emit}.3.1" -> 331,
     s"${TestModel.v3.emit}.3.2" -> 332
-  ).mapValues(_.toString)
+  )
 
-  private val testData2 = Map[String, Int](
+  private val testData2 = Map[String, Double](
     "lp__" -> 2,
     TestModel.v1.emit -> 0,
     s"${TestModel.v2.emit}.1" -> 1,
@@ -43,9 +43,9 @@ class StanResultsSpec extends ScalaStanBaseSpec {
     s"${TestModel.v3.emit}.2.2" -> 322,
     s"${TestModel.v3.emit}.3.1" -> 331,
     s"${TestModel.v3.emit}.3.2" -> 332
-  ).mapValues(_.toString)
+  )
 
-  val mappedData: Map[String, Vector[Vector[String]]] = Seq(testData1, testData2).flatten.groupBy(_._1).mapValues(
+  val mappedData: Map[String, Vector[Vector[Double]]] = Seq(testData1, testData2).flatten.groupBy(_._1).mapValues(
     grouped => Vector(grouped.map{ case(k, v) => v }.toVector)
   )
   val results = StanResults(mappedData, Vector.empty, model, RunMethod.Sample())


### PR DESCRIPTION
This has several small improvements that I didn't think were worthy of a PR each (broken out by commit instead):
* Add support for the `algebra_solver` functions.
* Fix for a null pointer exception that can happen when running multiple ScalaStan instances on the same box.  When removing old result files, ScalaStan now handles the case where another instance removed the file.
* ScalaStan now throws an exception with the error code from the model when the model fails.
* Improved parsing performance for the common case.  ScalaStan now stores results as Doubles instead of Strings, which means that we don't have to convert String -> Double multiple times if a result is used multiple times.  In addition, because each chain is parsed in parallel, the conversions happen in parallel, too.  On the other hand, if a result isn't used at all, the conversion is unnecessary.
* More robust parsing of results: ScalaStan now supports parsing NaN/-Inf/Inf (before it would just throw an exception since the encoding Stan uses doesn't match what Scala expects).
* `numElements` has been renamed to `num_elements` to match Stan.
* Added initial value support to locals.