### PR TITLE
Fix relative order of local declarations.

### DIFF
--- a/src/main/scala/com/cibo/scalastan/StanProgramBuilder.scala
+++ b/src/main/scala/com/cibo/scalastan/StanProgramBuilder.scala
@@ -59,10 +59,13 @@ class StanProgramBuilder {
     stack.last += ifStatement.copy(otherwise = Some(StanBlock(inside)))
   }
 
-  def insert(s: StanStatement): Unit = {
+  def insert(s: StanInlineDeclaration): Unit = {
     require(stack.nonEmpty)
     s.export(this)
-    stack.last.insert(0, s)
+
+    // Insert this statement after the last declaration.
+    val lastDeclIndex = stack.last.lastIndexWhere(_.isInstanceOf[StanInlineDeclaration])
+    stack.last.insert(lastDeclIndex + 1, s)
   }
 
   def append(other: StanProgramBuilder): Unit = {

--- a/src/test/scala/com/cibo/scalastan/StanModelSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/StanModelSpec.scala
@@ -70,6 +70,17 @@ class StanModelSpec extends ScalaStanBaseSpec {
       }
       checkCode(model, "model { real x = 2.5; x += 1.0; }")
     }
+
+    it("places multiple local declarations correctly inside loops") {
+      object model extends StanModel {
+        for (i <- range(1, 2)) {
+          val y = local(int())
+          val x = local(int(), y)
+          x += 1
+        }
+      }
+      checkCode(model, "model { for(ss_v# in 1:2) { int y; int x = y; x += 1; } }")
+    }
   }
 
   describe("model") {

--- a/src/test/scala/com/cibo/scalastan/transform/CSESpec.scala
+++ b/src/test/scala/com/cibo/scalastan/transform/CSESpec.scala
@@ -13,7 +13,7 @@ class CSESpec extends ScalaStanBaseSpec {
         z := y + 1
       }
 
-      checkCode(model.transform(CSE()), "model { real z; real y; real x; x = (y + 1); z = x; }")
+      checkCode(model.transform(CSE()), "model { real x; real y; real z; x = (y + 1); z = x; }")
     }
 
     it("re-orders multiplication") {
@@ -25,7 +25,7 @@ class CSESpec extends ScalaStanBaseSpec {
         z := 1 * y
       }
 
-      checkCode(model.transform(CSE()), "model { real z; real y; real x; x = (y * 1); z = x; }")
+      checkCode(model.transform(CSE()), "model { real x; real y; real z; x = (y * 1); z = x; }")
     }
 
     it("does not re-order division") {
@@ -37,7 +37,7 @@ class CSESpec extends ScalaStanBaseSpec {
         z := 1 / y
       }
 
-      checkCode(model.transform(CSE()), "model { real z; real y; real x; x = (y / 1); z = (1 / y); }")
+      checkCode(model.transform(CSE()), "model { real x; real y; real z; x = (y / 1); z = (1 / y); }")
     }
   }
 }

--- a/src/test/scala/com/cibo/scalastan/transform/CopyPropagationSpec.scala
+++ b/src/test/scala/com/cibo/scalastan/transform/CopyPropagationSpec.scala
@@ -13,7 +13,7 @@ class CopyPropagationSpec extends ScalaStanBaseSpec {
         y := z
         x := y
       }
-      checkCode(model.transform(CopyPropagation()), "model { real z; real x; x = z; }")
+      checkCode(model.transform(CopyPropagation()), "model { real x; real z; x = z; }")
     }
 
     it("handles conditionals") {
@@ -27,7 +27,7 @@ class CopyPropagationSpec extends ScalaStanBaseSpec {
           x := y
         }
       }
-      checkCode(model.transform(CopyPropagation()), "model { real z; real x; if(1) { x = z; } }")
+      checkCode(model.transform(CopyPropagation()), "model { real x; real z; if(1) { x = z; } }")
     }
 
     it("is conservative") {
@@ -42,7 +42,7 @@ class CopyPropagationSpec extends ScalaStanBaseSpec {
         }
         x := y
       }
-      checkCode(model.transform(CopyPropagation()), "model { real z; real y; real x; y = z; if(1) { y = 3; } x = y; }")
+      checkCode(model.transform(CopyPropagation()), "model { real x; real y; real z; y = z; if(1) { y = 3; } x = y; }")
     }
   }
 }


### PR DESCRIPTION
Now that locals can have initial values (see #109), their relative order matters.  For top-level locals, the order was being preserved, but the order was being reversed for locals declared in an inner scope such as a loop.  This fixes the order and adds a test.