### PR TITLE
Release 0.11.0

### DIFF
--- a/src/main/scala/com/cibo/scalastan/CommandRunner.scala
+++ b/src/main/scala/com/cibo/scalastan/CommandRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/CompatibleParCollections.scala
+++ b/src/main/scala/com/cibo/scalastan/CompatibleParCollections.scala
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
+ * You may use, distribute, and modify this code under the
+ * terms of the BSD 3-Clause license.
+ *
+ * A copy of the license can be found on the root of this repository,
+ * at https://github.com/cibotech/ScalaStan/blob/master/LICENSE,
+ * or at https://opensource.org/licenses/BSD-3-Clause
+ */
+
 package com.cibo.scalastan
 
 private[scalastan] object CompatibleParCollections {

--- a/src/main/scala/com/cibo/scalastan/CompiledModel.scala
+++ b/src/main/scala/com/cibo/scalastan/CompiledModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/DataMapping.scala
+++ b/src/main/scala/com/cibo/scalastan/DataMapping.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/Implicits.scala
+++ b/src/main/scala/com/cibo/scalastan/Implicits.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/RunMethod.scala
+++ b/src/main/scala/com/cibo/scalastan/RunMethod.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/SHA.scala
+++ b/src/main/scala/com/cibo/scalastan/SHA.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/ScalaStan.scala
+++ b/src/main/scala/com/cibo/scalastan/ScalaStan.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/StanCodeBlock.scala
+++ b/src/main/scala/com/cibo/scalastan/StanCodeBlock.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/StanContext.scala
+++ b/src/main/scala/com/cibo/scalastan/StanContext.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/StanDistributions.scala
+++ b/src/main/scala/com/cibo/scalastan/StanDistributions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/StanFunctions.scala
+++ b/src/main/scala/com/cibo/scalastan/StanFunctions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/StanModel.scala
+++ b/src/main/scala/com/cibo/scalastan/StanModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/StanProgramBuilder.scala
+++ b/src/main/scala/com/cibo/scalastan/StanProgramBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/StanResults.scala
+++ b/src/main/scala/com/cibo/scalastan/StanResults.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/StanTransformBase.scala
+++ b/src/main/scala/com/cibo/scalastan/StanTransformBase.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/StanType.scala
+++ b/src/main/scala/com/cibo/scalastan/StanType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/TransformedModel.scala
+++ b/src/main/scala/com/cibo/scalastan/TransformedModel.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/TypeCheck.scala
+++ b/src/main/scala/com/cibo/scalastan/TypeCheck.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/analysis/AvailableExpressions.scala
+++ b/src/main/scala/com/cibo/scalastan/analysis/AvailableExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/analysis/BitVectorAnalysis.scala
+++ b/src/main/scala/com/cibo/scalastan/analysis/BitVectorAnalysis.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/analysis/LiveVariables.scala
+++ b/src/main/scala/com/cibo/scalastan/analysis/LiveVariables.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/analysis/ReachingDefs.scala
+++ b/src/main/scala/com/cibo/scalastan/analysis/ReachingDefs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/analysis/StanAnalysis.scala
+++ b/src/main/scala/com/cibo/scalastan/analysis/StanAnalysis.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/analysis/UseDefinitions.scala
+++ b/src/main/scala/com/cibo/scalastan/analysis/UseDefinitions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/ast/StanDeclaration.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanDeclaration.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/ast/StanDistribution.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanDistribution.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/ast/StanNode.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanNode.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/ast/StanProgram.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanProgram.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/ast/StanStatement.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanStatement.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
+++ b/src/main/scala/com/cibo/scalastan/ast/StanValue.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/data/CsvDataSource.scala
+++ b/src/main/scala/com/cibo/scalastan/data/CsvDataSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/data/DataSource.scala
+++ b/src/main/scala/com/cibo/scalastan/data/DataSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/data/RDataSource.scala
+++ b/src/main/scala/com/cibo/scalastan/data/RDataSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/data/TextDataSource.scala
+++ b/src/main/scala/com/cibo/scalastan/data/TextDataSource.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/models/ARkRegression.scala
+++ b/src/main/scala/com/cibo/scalastan/models/ARkRegression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/models/Horseshoe.scala
+++ b/src/main/scala/com/cibo/scalastan/models/Horseshoe.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/models/LinearRegression.scala
+++ b/src/main/scala/com/cibo/scalastan/models/LinearRegression.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/models/NaiveBayes.scala
+++ b/src/main/scala/com/cibo/scalastan/models/NaiveBayes.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/models/SoftKMeans.scala
+++ b/src/main/scala/com/cibo/scalastan/models/SoftKMeans.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/run/CmdStanCompiler.scala
+++ b/src/main/scala/com/cibo/scalastan/run/CmdStanCompiler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/run/CmdStanRunner.scala
+++ b/src/main/scala/com/cibo/scalastan/run/CmdStanRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/run/StanCompiler.scala
+++ b/src/main/scala/com/cibo/scalastan/run/StanCompiler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/run/StanException.scala
+++ b/src/main/scala/com/cibo/scalastan/run/StanException.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/run/StanRunner.scala
+++ b/src/main/scala/com/cibo/scalastan/run/StanRunner.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/transform/AstSimplifier.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/AstSimplifier.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/transform/CSE.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/CSE.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/transform/CopyPropagation.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/CopyPropagation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/transform/LoopChecker.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/LoopChecker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/transform/Optimize.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/Optimize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/transform/RemoveUnusedDecls.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/RemoveUnusedDecls.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/transform/SplitExpressions.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/SplitExpressions.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/transform/StanTransform.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/StanTransform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/transform/StrengthReduction.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/StrengthReduction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/src/main/scala/com/cibo/scalastan/transform/SubstituteVariables.scala
+++ b/src/main/scala/com/cibo/scalastan/transform/SubstituteVariables.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 - 2021 CiBO Technologies - All Rights Reserved
+ * Copyright (c) 2017 - 2023 CiBO Technologies - All Rights Reserved
  * You may use, distribute, and modify this code under the
  * terms of the BSD 3-Clause license.
  *

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.0"
+version in ThisBuild := "0.11.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.10.2-SNAPSHOT"
+version in ThisBuild := "0.11.0"


### PR DESCRIPTION
- Cross-compile for 2.12 and 2.13.

Artifacts for 2.12 and 2.13 are available at https://s01.oss.sonatype.org/#nexus-search;quick~scalastan.

There are no code changes in this PR; it's mainly just updating headers because `sbt headerCheck`, which is part of the `sbt release` flow, errors out if the copyright headers aren't up to date.

This repo does not have a CHANGELOG or a GH Pages site, so no documentation needs to be updated.